### PR TITLE
Add cross-mission export utility and reusable training APIs

### DIFF
--- a/src/exo_tabular.py
+++ b/src/exo_tabular.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import joblib
 import numpy as np
@@ -102,13 +102,33 @@ def build_artifact_paths(artifacts_dir: Path, mode_tag: str) -> Dict[str, Path]:
     }
 
 
-def train_cross_mission(
-    args: argparse.Namespace,
+def _prepare_cross_mission_artifacts(
+    test_mission: str,
+    artifacts_dir: Path,
+    prefix: Optional[str] = None,
+) -> Dict[str, Path]:
+    tag = prefix if prefix is not None else test_mission
+    return {
+        "model": artifacts_dir / f"model_{tag}.pkl",
+        "metrics": artifacts_dir / f"metrics_{tag}.json",
+        "roc": artifacts_dir / f"roc_{tag}.png",
+        "pr": artifacts_dir / f"pr_{tag}.png",
+        "confusion": artifacts_dir / f"confusion_{tag}.png",
+        "schema": artifacts_dir / f"{tag}_feature_columns.json",
+    }
+
+
+def _train_cross_mission_core(
+    test_mission: str,
     data_dir: Path,
     artifacts: Dict[str, Path],
+    *,
+    device: str,
+    ensemble: bool,
+    random_state: int,
     logger: logging.Logger,
-) -> None:
-    train_dataset, test_dataset = load_cross_mission_split(args.test_mission, data_dir, logger)
+) -> Path:
+    train_dataset, test_dataset = load_cross_mission_split(test_mission, data_dir, logger)
     log_label_distribution("train", train_dataset, logger)
     log_label_distribution("test", test_dataset, logger)
     X_train, y_train = train_dataset.features, train_dataset.labels
@@ -121,27 +141,130 @@ def train_cross_mission(
         categorical_cols,
         X_train,
         y_train,
-        device=args.device,
-        ensemble=args.ensemble,
+        device=device,
+        ensemble=ensemble,
         logger=logger,
-        random_state=args.random_state,
+        random_state=random_state,
     )
     proba = pipeline.predict_proba(X_test)[:, 1]
     metrics = evaluate_binary_classification(y_test, proba, thresholds=(0.5, 0.95))
     metrics["configuration"] = {
         "mode": "train",
-        "split": args.split,
-        "test_mission": args.test_mission,
-        "ensemble": args.ensemble,
-        "device": args.device,
+        "split": "cross-mission",
+        "test_mission": test_mission,
+        "ensemble": ensemble,
+        "device": device,
     }
-    save_metrics(metrics, artifacts["metrics"])
-    plot_roc_curve(y_test, proba, artifacts["roc"])
-    plot_pr_curve(y_test, proba, artifacts["pr"])
-    plot_confusion_matrix(y_test, proba, threshold=0.5, output_path=artifacts["confusion"])
-    joblib.dump(pipeline, artifacts["model"])
-    save_feature_schema(X_train.columns, artifacts["schema"])
-    logger.info("Saved model to %s", artifacts["model"])
+    if "metrics" in artifacts:
+        save_metrics(metrics, artifacts["metrics"])
+    if "roc" in artifacts:
+        plot_roc_curve(y_test, proba, artifacts["roc"])
+    if "pr" in artifacts:
+        plot_pr_curve(y_test, proba, artifacts["pr"])
+    if "confusion" in artifacts:
+        plot_confusion_matrix(y_test, proba, threshold=0.5, output_path=artifacts["confusion"])
+    model_path = artifacts.get("model")
+    if model_path is not None:
+        joblib.dump(pipeline, model_path)
+        logger.info("Saved model to %s", model_path)
+    else:
+        raise KeyError("Cross-mission training requires a 'model' artifact path.")
+    if "schema" in artifacts:
+        save_feature_schema(X_train.columns, artifacts["schema"])
+        logger.info("Saved feature schema to %s", artifacts["schema"])
+    return model_path
+
+
+def train_cross_mission(
+    test_mission: str,
+    data_dir: Path,
+    artifacts_dir: Path,
+    *,
+    device: str = "cpu",
+    ensemble: bool = False,
+    random_state: int = DEFAULT_RANDOM_STATE,
+    logger: Optional[logging.Logger] = None,
+) -> Path:
+    logger = logger or logging.getLogger("exo_tabular")
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = _prepare_cross_mission_artifacts(test_mission, artifacts_dir)
+    return _train_cross_mission_core(
+        test_mission,
+        data_dir,
+        artifacts,
+        device=device,
+        ensemble=ensemble,
+        random_state=random_state,
+        logger=logger,
+    )
+
+
+def _load_cross_mission_predictions(
+    test_mission: str,
+    data_dir: Path,
+    *,
+    model_path: Path,
+    schema_path: Path,
+    logger: logging.Logger,
+) -> pd.DataFrame:
+    if not model_path.exists():
+        raise FileNotFoundError(f"Trained model not found at {model_path}")
+    if not schema_path.exists():
+        raise FileNotFoundError(f"Feature schema not found at {schema_path}")
+    pipeline = joblib.load(model_path)
+    schema = load_feature_schema(schema_path)
+    _, test_dataset = load_cross_mission_split(test_mission, data_dir, logger)
+    log_label_distribution("prediction_target", test_dataset, logger)
+    features = align_to_schema(test_dataset.features, schema)
+    log_feature_set(features, logger)
+    proba = pipeline.predict_proba(features)[:, 1]
+    base = pd.DataFrame(
+        {
+            "object_id": test_dataset.metadata["object_id"].values,
+            "mission": test_dataset.metadata["mission"].values,
+            "proba_planet": proba,
+        }
+    )
+    metadata_columns = ["object_id", "mission", "label_text"]
+    for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
+        if column in test_dataset.metadata:
+            metadata_columns.append(column)
+    metadata = test_dataset.metadata.loc[:, metadata_columns].copy()
+    merged = base.merge(metadata, on=["object_id", "mission"], how="left")
+    missing = merged["label_text"].isna().sum()
+    if missing:
+        logger.warning(
+            "Metadata join missing for %d samples (mission=%s)",
+            missing,
+            test_mission,
+        )
+    keep_order = ["object_id", "mission", "proba_planet"]
+    for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
+        if column in merged.columns:
+            keep_order.append(column)
+    if "label_text" in merged.columns:
+        keep_order.append("label_text")
+    return merged.loc[:, keep_order]
+
+
+def predict_cross_mission(
+    test_mission: str,
+    data_dir: Path,
+    artifacts_dir: Path,
+    model_path: Optional[Path] = None,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> pd.DataFrame:
+    logger = logger or logging.getLogger("exo_tabular")
+    effective_model_path = model_path or artifacts_dir / f"model_{test_mission}.pkl"
+    schema_path = artifacts_dir / f"{test_mission}_feature_columns.json"
+    return _load_cross_mission_predictions(
+        test_mission,
+        data_dir,
+        model_path=effective_model_path,
+        schema_path=schema_path,
+        logger=logger,
+    )
 
 
 def train_group_kfold(
@@ -211,35 +334,40 @@ def predict_dataset(
 ) -> None:
     model_path = artifacts["model"]
     schema_path = artifacts["schema"]
-    if not model_path.exists():
-        raise FileNotFoundError(f"Trained model not found at {model_path}")
-    if not schema_path.exists():
-        raise FileNotFoundError(f"Feature schema not found at {schema_path}")
-    pipeline = joblib.load(model_path)
-    schema = load_feature_schema(schema_path)
     if args.split == "cross-mission":
-        _, dataset = load_cross_mission_split(args.test_mission, data_dir, logger)
-        target_dataset = dataset
+        predictions = _load_cross_mission_predictions(
+            args.test_mission,
+            data_dir,
+            model_path=model_path,
+            schema_path=schema_path,
+            logger=logger,
+        )
+        predictions["bucket"] = assign_bucket(predictions["proba_planet"].to_numpy())
     else:
+        if not model_path.exists():
+            raise FileNotFoundError(f"Trained model not found at {model_path}")
+        if not schema_path.exists():
+            raise FileNotFoundError(f"Feature schema not found at {schema_path}")
+        pipeline = joblib.load(model_path)
+        schema = load_feature_schema(schema_path)
         if not args.mission:
             raise ValueError("--mission must be provided for group-kfold split")
         target_dataset = load_mission_dataset(args.mission, data_dir, logger)
-    log_label_distribution("prediction_target", target_dataset, logger)
-    features = align_to_schema(target_dataset.features, schema)
-    log_feature_set(features, logger)
-    proba = pipeline.predict_proba(features)[:, 1]
-    buckets = assign_bucket(proba)
-    predictions = pd.DataFrame(
-        {
-            "object_id": target_dataset.metadata["object_id"].values,
-            "mission": target_dataset.metadata["mission"].values,
-            "proba_planet": proba,
-            "bucket": buckets,
-        }
-    )
-    for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
-        if column in target_dataset.metadata:
-            predictions[column] = target_dataset.metadata[column].values
+        log_label_distribution("prediction_target", target_dataset, logger)
+        features = align_to_schema(target_dataset.features, schema)
+        log_feature_set(features, logger)
+        proba = pipeline.predict_proba(features)[:, 1]
+        predictions = pd.DataFrame(
+            {
+                "object_id": target_dataset.metadata["object_id"].values,
+                "mission": target_dataset.metadata["mission"].values,
+                "proba_planet": proba,
+                "bucket": assign_bucket(proba),
+            }
+        )
+        for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
+            if column in target_dataset.metadata:
+                predictions[column] = target_dataset.metadata[column].values
     predictions.to_csv(artifacts["predictions"], index=False)
     logger.info("Saved predictions to %s", artifacts["predictions"])
 
@@ -249,12 +377,25 @@ def main(argv: Iterable[str]) -> None:
     args = parse_args(argv)
     logger = logging.getLogger("exo_tabular")
     _, data_dir, artifacts_dir = get_project_paths()
-    mode_tag = args.split
+    if args.split == "cross-mission":
+        mode_tag = f"{args.split}_{args.test_mission}"
+    elif args.split == "group-kfold" and args.mission:
+        mode_tag = f"{args.split}_{args.mission}"
+    else:
+        mode_tag = args.split
     artifacts = build_artifact_paths(artifacts_dir, mode_tag)
     logger.info("Running mode=%s split=%s", args.mode, args.split)
     if args.mode == "train":
         if args.split == "cross-mission":
-            train_cross_mission(args, data_dir, artifacts, logger)
+            _train_cross_mission_core(
+                args.test_mission,
+                data_dir,
+                artifacts,
+                device=args.device,
+                ensemble=args.ensemble,
+                random_state=args.random_state,
+                logger=logger,
+            )
         else:
             train_group_kfold(args, data_dir, artifacts, logger)
     else:

--- a/src/export_predictions.py
+++ b/src/export_predictions.py
@@ -1,0 +1,242 @@
+"""Export cross-mission prediction buckets and reports.
+
+Usage example::
+
+    conda activate exoplanets
+    python -m src.export_predictions \
+      --data-dir ~/nasa/data \
+      --artifacts-dir ~/nasa/artifacts \
+      --runs cross-mission \
+      --threshold-planet 0.95 \
+      --threshold-candidate 0.50
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+from exo_tabular import predict_cross_mission, train_cross_mission
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export exoplanet prediction buckets")
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--runs", choices=["cross-mission"], required=True)
+    parser.add_argument("--threshold-planet", type=float, default=0.95)
+    parser.add_argument("--threshold-candidate", type=float, default=0.5)
+    parser.add_argument("--device", choices=["cpu", "gpu"], default="cpu")
+    parser.add_argument("--ensemble", action="store_true", help="Enable ensemble training")
+    parser.add_argument("--random-state", type=int, default=42)
+    return parser.parse_args(list(argv))
+
+
+def configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+def bucketize(probability: float, th_planet: float = 0.95, th_candidate: float = 0.50) -> str:
+    if probability >= th_planet:
+        return "planet"
+    if probability >= th_candidate:
+        return "candidate"
+    return "non-planet"
+
+
+def nasa_bucket(label_text: str, mission: str) -> str:
+    s = (label_text or "").strip().lower()
+    mission_key = mission.lower()
+    if mission_key in ("kepler", "k2"):
+        if s == "confirmed":
+            return "planet"
+        if s == "candidate":
+            return "candidate"
+        return "non-planet"
+    if mission_key == "tess":
+        if s in ("cp", "kp"):
+            return "planet"
+        if s == "pc":
+            return "candidate"
+        return "non-planet"
+    return "non-planet"
+
+
+def _ensure_columns(df: pd.DataFrame, desired: List[str]) -> pd.DataFrame:
+    existing = [col for col in desired if col in df.columns]
+    return df.loc[:, existing]
+
+
+def _write_csv(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def _write_summary(
+    df: pd.DataFrame,
+    thresholds: Dict[str, float],
+    path: Path,
+) -> None:
+    lines: List[str] = []
+    lines.append("Category counts:")
+    counts = df["category"].value_counts().sort_index()
+    for label, value in counts.items():
+        lines.append(f"  {label}: {int(value)}")
+    lines.append("")
+    lines.append("NASA category counts:")
+    nasa_counts = df["nasa_category"].value_counts().sort_index()
+    for label, value in nasa_counts.items():
+        lines.append(f"  {label}: {int(value)}")
+    lines.append("")
+    lines.append("Category vs NASA category:")
+    matrix = pd.crosstab(df["category"], df["nasa_category"], dropna=False)
+    matrix = matrix.reindex(index=sorted(matrix.index), columns=sorted(matrix.columns))
+    lines.append(matrix.to_string())
+    lines.append("")
+    lines.append("Thresholds:")
+    for name, value in thresholds.items():
+        lines.append(f"  {name}: {value}")
+    path.write_text("\n".join(lines))
+
+
+def _prepare_predictions(
+    mission: str,
+    predictions: pd.DataFrame,
+    thresholds: Dict[str, float],
+) -> pd.DataFrame:
+    df = predictions.copy()
+    df["category"] = df["proba_planet"].apply(
+        bucketize,
+        th_planet=thresholds["planet"],
+        th_candidate=thresholds["candidate"],
+    )
+    df["confidence_pct"] = df["proba_planet"] * 100.0
+    label_series = df.get("label_text", pd.Series("", index=df.index, dtype=str))
+    mission_series = df.get("mission", pd.Series(mission, index=df.index, dtype=str))
+    df["nasa_category"] = [
+        nasa_bucket(label, mission_value)
+        for label, mission_value in zip(label_series, mission_series)
+    ]
+    return df
+
+
+def _log_join_gaps(df: pd.DataFrame, mission: str, logger: logging.Logger) -> None:
+    label_series = df.get("label_text")
+    if label_series is None:
+        logger.warning("label_text metadata missing for mission %s", mission)
+        return
+    missing = label_series.isna().sum()
+    if missing:
+        logger.warning("%d predictions missing metadata join for mission %s", missing, mission)
+
+
+def run_cross_mission(args: argparse.Namespace) -> None:
+    logger = logging.getLogger("export_predictions")
+    data_dir = args.data_dir
+    artifacts_dir = args.artifacts_dir
+    thresholds = {"planet": args.threshold_planet, "candidate": args.threshold_candidate}
+    missions = ["tess", "k2", "kepler"]
+
+    for mission in missions:
+        logger.info("Training cross-mission model (test=%s)", mission)
+        model_path = train_cross_mission(
+            mission,
+            data_dir,
+            artifacts_dir,
+            device=args.device,
+            ensemble=args.ensemble,
+            random_state=args.random_state,
+            logger=logger,
+        )
+        logger.info("Predicting mission %s", mission)
+        predictions = predict_cross_mission(
+            mission,
+            data_dir,
+            artifacts_dir,
+            model_path=model_path,
+            logger=logger,
+        )
+        _log_join_gaps(predictions, mission, logger)
+        prepared = _prepare_predictions(mission, predictions, thresholds)
+        export_dir = artifacts_dir / "exports" / mission
+        export_dir.mkdir(parents=True, exist_ok=True)
+        ordered_columns = [
+            "object_id",
+            "mission",
+            "proba_planet",
+            "confidence_pct",
+            "category",
+            "period",
+            "t0",
+            "duration",
+            "depth",
+            "rp",
+            "teq",
+            "insolation",
+            "eccentricity",
+            "sma",
+            "snr",
+            "impact",
+            "mes",
+        ]
+        predictions_out = _ensure_columns(prepared, ordered_columns)
+        _write_csv(predictions_out, export_dir / f"predictions_{mission}.csv")
+
+        for label, filename in (
+            ("planet", f"planets_{mission}.csv"),
+            ("candidate", f"candidates_{mission}.csv"),
+            ("non-planet", f"non_planets_{mission}.csv"),
+        ):
+            subset = prepared.loc[prepared["category"] == label]
+            subset_out = _ensure_columns(subset, ordered_columns + ["nasa_category"])
+            _write_csv(subset_out, export_dir / filename)
+
+        discrepancy_specs = [
+            (
+                (prepared["category"] == "planet") & (prepared["nasa_category"] == "non-planet"),
+                f"pred_planet_nasa_nonplanet_{mission}.csv",
+            ),
+            (
+                (prepared["category"] == "planet") & (prepared["nasa_category"] == "candidate"),
+                f"pred_planet_nasa_candidate_{mission}.csv",
+            ),
+            (
+                (prepared["category"] == "candidate") & (prepared["nasa_category"] == "non-planet"),
+                f"pred_candidate_nasa_nonplanet_{mission}.csv",
+            ),
+            (
+                (prepared["category"] == "non-planet") & (prepared["nasa_category"] == "planet"),
+                f"pred_nonplanet_nasa_planet_{mission}.csv",
+            ),
+            (
+                (prepared["category"] == "non-planet") & (prepared["nasa_category"] == "candidate"),
+                f"pred_nonplanet_nasa_candidate_{mission}.csv",
+            ),
+        ]
+        discrepancy_columns = ordered_columns + ["nasa_category", "label_text"]
+        for mask, filename in discrepancy_specs:
+            subset = prepared.loc[mask]
+            subset_out = _ensure_columns(subset, discrepancy_columns)
+            _write_csv(subset_out, export_dir / filename)
+
+        summary_path = export_dir / f"summary_{mission}.txt"
+        _write_summary(prepared, thresholds, summary_path)
+        logger.info("Finished exports for mission %s", mission)
+
+
+def main(argv: Iterable[str]) -> None:
+    configure_logging()
+    args = parse_args(argv)
+    if args.runs != "cross-mission":
+        raise NotImplementedError("Only cross-mission run is currently supported.")
+    run_cross_mission(args)
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- expose reusable cross-mission train/predict helpers from `exo_tabular.py` while keeping the existing CLI entry point
- add `src/export_predictions.py` CLI to train the three cross-mission folds, bucketize predictions, and export filtered CSVs plus summaries

## Testing
- python -m compileall src/export_predictions.py src/exo_tabular.py

------
https://chatgpt.com/codex/tasks/task_e_68e181b52d388326b7e317e029208e43