### PR TITLE
Improve imbalance handling and threshold calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 In this repository we are developing a deep learning model to detect and classify exoplanets. # AstroVision
+
+## Recent pipeline enhancements
+
+- **Balanced training** – the `exo_tabular` training commands now weight each sample inversely to its class frequency, helping the classifier pay more attention to the rare confirmed exoplanets.
+- **Optional oversampling** – pass `--oversample` to `python -m src.exo_tabular ...` or `python -m src.export_predictions ...` to duplicate minority-class examples with an internal `RandomOverSampler` (requires `imbalanced-learn`).
+- **Calibrated thresholds** – provide a target recall via `--recall-target` (default `0.6`). The training reports (`metrics_*.json`) include a recommended probability threshold that achieves at least that recall, and prediction modes can consume it with `--use-calibrated-buckets`/`--use-calibrated-thresholds` to adjust the candidate bucket.
+
+Make sure `imbalanced-learn` is installed to enable the oversampling option:
+
+```bash
+pip install imbalanced-learn
+```


### PR DESCRIPTION
## Summary
- add balanced class weighting, optional oversampling, and automatic recall-based threshold calibration in the core modeling utilities
- expose oversampling and calibrated threshold options through the CLI and export scripts so predictions can use mission-specific candidate cutoffs
- document the new workflow steps required to enable oversampling in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e22b0c0b048326808b2a6eb1043395