### PR TITLE
Improve within-mission export calibration and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 In this repository we are developing a deep learning model to detect and classify exoplanets. # AstroVision
+
+## Recent pipeline enhancements
+
+- **Balanced training** – the `exo_tabular` training commands now weight each sample inversely to its class frequency, helping the classifier pay more attention to the rare confirmed exoplanets.
+- **Optional oversampling** – pass `--oversample` to `python -m src.exo_tabular ...` or `python -m src.export_predictions ...` to duplicate minority-class examples with an internal `RandomOverSampler` (requires `imbalanced-learn`).
+- **Calibrated thresholds** – provide a target recall via `--recall-target` (default `0.6`). The training reports (`metrics_*.json`) include a recommended probability threshold that achieves at least that recall, and prediction modes can consume it with `--use-calibrated-buckets`/`--use-calibrated-thresholds` to adjust the candidate bucket.
+- **Within-mission exports** – `python -m src.export_within_mission ...` now oversamples the positive class by default, records calibrated candidate thresholds that hit the desired recall, saves both JSON and text metric reports, and uses the calibrated threshold automatically unless `--keep-default-thresholds` is provided.
+
+Make sure `imbalanced-learn` is installed to enable the oversampling option:
+
+```bash
+pip install imbalanced-learn
+```

--- a/src/export_within_mission.py
+++ b/src/export_within_mission.py
@@ -22,14 +22,7 @@ from pathlib import Path
 from typing import Iterable, List, Sequence
 
 import joblib
-import numpy as np
 import pandas as pd
-from sklearn.metrics import (
-    average_precision_score,
-    confusion_matrix,
-    precision_recall_fscore_support,
-    roc_auc_score,
-)
 from sklearn.model_selection import StratifiedShuffleSplit
 
 if __package__ in (None, ""):
@@ -39,7 +32,12 @@ if __package__ in (None, ""):
         nasa_bucket,
         save_feature_schema,
     )
-    from modeling import build_lightgbm_pipeline
+    from modeling import (
+        build_pipeline,
+        evaluate_binary_classification,
+        fit_pipeline_with_fallback,
+        save_metrics,
+    )
 else:
     from .dataio import (
         infer_feature_types,
@@ -47,7 +45,12 @@ else:
         nasa_bucket,
         save_feature_schema,
     )
-    from .modeling import build_lightgbm_pipeline
+    from .modeling import (
+        build_pipeline,
+        evaluate_binary_classification,
+        fit_pipeline_with_fallback,
+        save_metrics,
+    )
 
 
 PHYSICAL_EXPORT_COLUMNS: Sequence[str] = (
@@ -92,6 +95,26 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--threshold-planet", type=float, default=0.95)
     parser.add_argument("--threshold-candidate", type=float, default=0.50)
+    parser.add_argument("--device", choices=["cpu", "gpu"], default="cpu")
+    parser.add_argument("--ensemble", action="store_true", help="Enable stacking ensemble")
+    parser.add_argument(
+        "--recall-target",
+        type=float,
+        default=0.6,
+        help="Recall target used to calibrate candidate threshold",
+    )
+    parser.add_argument(
+        "--keep-default-thresholds",
+        action="store_true",
+        help="Use provided thresholds even if calibrated values are available",
+    )
+    parser.add_argument(
+        "--no-oversample",
+        dest="oversample",
+        action="store_false",
+        help="Disable RandomOverSampler augmentation (enabled by default)",
+    )
+    parser.set_defaults(oversample=True)
     return parser.parse_args(list(argv))
 
 
@@ -121,31 +144,76 @@ def _select_missions(raw: Sequence[str] | None) -> List[str]:
     return normalized
 
 
-def _format_metrics_text(
-    roc_auc: float,
-    pr_auc: float,
-    precision: float,
-    recall: float,
-    f1: float,
-    support: float | None,
-    confusion: np.ndarray,
-    test_size: float,
-    seed: int,
-) -> str:
-    lines = [
-        f"ROC-AUC: {roc_auc:.4f}",
-        f"PR-AUC: {pr_auc:.4f}",
-        f"Precision (threshold=0.5): {precision:.4f}",
-        f"Recall (threshold=0.5): {recall:.4f}",
-        f"F1 (threshold=0.5): {f1:.4f}",
-        f"Support (positive class): {int(support) if support is not None else 'n/a'}",
-        "",
-        "Confusion matrix (threshold=0.5):",
-        str(confusion),
-        "",
-        f"Test size: {test_size}",
-        f"Seed: {seed}",
-    ]
+def _format_metrics_text(metrics: dict[str, object], test_size: float, seed: int) -> str:
+    lines: List[str] = []
+    roc_auc = metrics.get("roc_auc")
+    pr_auc = metrics.get("pr_auc")
+    positive_rate = metrics.get("positive_rate")
+    if roc_auc is not None:
+        lines.append(f"ROC-AUC: {roc_auc:.4f}")
+    if pr_auc is not None:
+        lines.append(f"PR-AUC: {pr_auc:.4f}")
+    if positive_rate is not None:
+        lines.append(f"Positive rate: {positive_rate:.4f}")
+    lines.append("")
+    lines.append("Threshold metrics:")
+    threshold_metrics = metrics.get("thresholds", {})
+    ordered_keys: List[str] = []
+    numeric_keys = [k for k in threshold_metrics.keys() if k not in {"calibrated"}]
+    ordered_keys.extend(sorted(numeric_keys, key=float))
+    if "calibrated" in threshold_metrics:
+        ordered_keys.append("calibrated")
+    def _fmt_float(value: object) -> str:
+        if value is None:
+            return "nan"
+        try:
+            return f"{float(value):.4f}"
+        except (TypeError, ValueError):
+            return "nan"
+
+    def _fmt_int(value: object) -> str:
+        if value is None:
+            return "n/a"
+        try:
+            return str(int(value))
+        except (TypeError, ValueError):
+            return "n/a"
+
+    for key in ordered_keys:
+        values = threshold_metrics.get(key, {})
+        label = "calibrated" if key == "calibrated" else f"threshold={float(key):.2f}"
+        precision = _fmt_float(values.get("precision"))
+        recall = _fmt_float(values.get("recall"))
+        f1 = _fmt_float(values.get("f1"))
+        predicted = _fmt_int(values.get("predicted_positive"))
+        lines.append(
+            f"  {label}: precision={precision} recall={recall} f1={f1} predicted_positive={predicted}"
+        )
+    lines.append("")
+    confusion = metrics.get("confusion_matrix", {})
+    tn = confusion.get("tn", 0)
+    fp = confusion.get("fp", 0)
+    fn = confusion.get("fn", 0)
+    tp = confusion.get("tp", 0)
+    lines.append("Confusion matrix (threshold=0.5):")
+    lines.append(f"  [[TN={tn}, FP={fp}], [FN={fn}, TP={tp}]]")
+    lines.append("")
+    lines.append(f"Test size: {test_size}")
+    lines.append(f"Seed: {seed}")
+    recommended = metrics.get("recommended_threshold")
+    if isinstance(recommended, dict):
+        th = _fmt_float(recommended.get("threshold"))
+        rec = _fmt_float(recommended.get("recall"))
+        prec = _fmt_float(recommended.get("precision"))
+        f1 = _fmt_float(recommended.get("f1"))
+        lines.append("")
+        lines.append(
+            "Recommended threshold: "
+            f"threshold={th} precision={prec} recall={rec} f1={f1}"
+        )
+        target = recommended.get("recall_target")
+        if target is not None:
+            lines.append(f"Recall target: {target:.2f}")
     return "\n".join(lines)
 
 
@@ -203,10 +271,57 @@ def _write_text(content: str, path: Path) -> None:
     path.write_text(content)
 
 
+def _fit_with_optional_oversample(
+    numeric_cols: Sequence[str],
+    categorical_cols: Sequence[str],
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    args: argparse.Namespace,
+    logger: logging.Logger,
+) -> tuple[object, bool]:
+    try:
+        pipeline = fit_pipeline_with_fallback(
+            build_pipeline,
+            numeric_cols,
+            categorical_cols,
+            X,
+            y,
+            device=args.device,
+            ensemble=args.ensemble,
+            logger=logger,
+            random_state=args.seed,
+            builder_kwargs={"oversample": args.oversample},
+        )
+        return pipeline, args.oversample
+    except ImportError as exc:
+        if args.oversample:
+            logger.warning(
+                "Oversampling requested but unavailable (%s). Continuing without RandomOverSampler.",
+                exc,
+            )
+            pipeline = fit_pipeline_with_fallback(
+                build_pipeline,
+                numeric_cols,
+                categorical_cols,
+                X,
+                y,
+                device=args.device,
+                ensemble=args.ensemble,
+                logger=logger,
+                random_state=args.seed,
+                builder_kwargs={"oversample": False},
+            )
+            return pipeline, False
+        raise
+
+
 def _build_summary(
     df: pd.DataFrame,
     mission: str,
     thresholds: dict[str, float],
+    base_thresholds: dict[str, float],
+    metrics: dict[str, object],
     test_size: float,
     seed: int,
     join_missing: int,
@@ -236,9 +351,51 @@ def _build_summary(
     lines.append("Prediction vs NASA category matrix:")
     lines.append(matrix.fillna(0).astype(int).to_string())
     lines.append("")
-    lines.append("Thresholds:")
+    lines.append("Thresholds used for export:")
     for key, value in thresholds.items():
         lines.append(f"  {key}: {value}")
+    lines.append("")
+    lines.append("Base thresholds requested:")
+    for key, value in base_thresholds.items():
+        lines.append(f"  {key}: {value}")
+    recommended = metrics.get("recommended_threshold")
+    if isinstance(recommended, dict):
+        lines.append("")
+        lines.append("Calibrated candidate threshold (recall target):")
+        lines.append(
+            "  threshold={threshold:.4f} precision={precision:.4f} recall={recall:.4f} f1={f1:.4f} target={target}".format(
+                threshold=float(recommended.get("threshold", float("nan"))),
+                precision=float(recommended.get("precision", float("nan"))),
+                recall=float(recommended.get("recall", float("nan"))),
+                f1=float(recommended.get("f1", float("nan"))),
+                target=recommended.get("recall_target", "n/a"),
+            )
+        )
+    lines.append("")
+    lines.append("Holdout metrics (threshold=0.50):")
+    threshold_metrics = metrics.get("thresholds", {}).get("0.5", {})
+    lines.append(
+        "  precision={precision:.4f} recall={recall:.4f} f1={f1:.4f} predicted_positive={predicted}".format(
+            precision=float(threshold_metrics.get("precision", float("nan"))),
+            recall=float(threshold_metrics.get("recall", float("nan"))),
+            f1=float(threshold_metrics.get("f1", float("nan"))),
+            predicted=int(threshold_metrics.get("predicted_positive", 0)),
+        )
+    )
+    lines.append("  confusion_matrix=[[{tn}, {fp}], [{fn}, {tp}]]".format(**{
+        "tn": metrics.get("confusion_matrix", {}).get("tn", 0),
+        "fp": metrics.get("confusion_matrix", {}).get("fp", 0),
+        "fn": metrics.get("confusion_matrix", {}).get("fn", 0),
+        "tp": metrics.get("confusion_matrix", {}).get("tp", 0),
+    }))
+    lines.append("")
+    lines.append(
+        "ROC-AUC={roc:.4f} PR-AUC={pr:.4f} positive_rate={pos:.4f}".format(
+            roc=float(metrics.get("roc_auc", float("nan"))),
+            pr=float(metrics.get("pr_auc", float("nan"))),
+            pos=float(metrics.get("positive_rate", float("nan"))),
+        )
+    )
     lines.append("")
     lines.append(f"Test size: {test_size}")
     lines.append(f"Seed: {seed}")
@@ -263,20 +420,18 @@ def _export_diffs(df: pd.DataFrame, export_dir: Path, mission: str) -> None:
 
 def process_mission(
     mission: str,
-    data_dir: Path,
+    args: argparse.Namespace,
     artifacts_dir: Path,
-    test_size: float,
-    seed: int,
-    thresholds: dict[str, float],
+    base_thresholds: dict[str, float],
     logger: logging.Logger,
 ) -> None:
     logger.info("Processing mission %s", mission)
-    dataset = load_mission_dataset(mission, data_dir, logger)
+    dataset = load_mission_dataset(mission, args.data_dir, logger)
     features = dataset.features
     labels = dataset.labels
     metadata = dataset.metadata
 
-    splitter = StratifiedShuffleSplit(n_splits=1, test_size=test_size, random_state=seed)
+    splitter = StratifiedShuffleSplit(n_splits=1, test_size=args.test_size, random_state=args.seed)
     train_indices, test_indices = next(splitter.split(features, labels))
     X_train = features.iloc[train_indices].copy()
     y_train = labels.iloc[train_indices].copy()
@@ -286,59 +441,93 @@ def process_mission(
         "Mission %s: %d train samples, %d test samples", mission, X_train.shape[0], X_test.shape[0]
     )
 
-    numeric_cols, categorical_cols = infer_feature_types(X_train)
+    numeric_cols, categorical_cols = infer_feature_types(features)
     logger.info(
         "Mission %s: %d numeric features, %d categorical features",
         mission,
         len(numeric_cols),
         len(categorical_cols),
     )
-    pipeline = build_lightgbm_pipeline(numeric_cols, categorical_cols, random_state=seed)
-    logger.info("Training LightGBM pipeline on CPU for mission %s", mission)
-    pipeline.fit(X_train, y_train)
+
+    pipeline, oversample_used = _fit_with_optional_oversample(
+        numeric_cols,
+        categorical_cols,
+        X_train,
+        y_train,
+        args=args,
+        logger=logger,
+    )
 
     proba_test = pipeline.predict_proba(X_test)[:, 1]
-    predictions_test = (proba_test >= 0.5).astype(int)
-    roc_auc = roc_auc_score(y_test, proba_test)
-    pr_auc = average_precision_score(y_test, proba_test)
-    precision, recall, f1, support = precision_recall_fscore_support(
+    metrics = evaluate_binary_classification(
         y_test,
-        predictions_test,
-        average="binary",
-        zero_division=0,
+        proba_test,
+        thresholds=(0.5, 0.95),
+        recall_target=args.recall_target,
     )
-    confusion = confusion_matrix(y_test, predictions_test)
-    positive_support = int((y_test == 1).sum())
+    metrics["configuration"] = {
+        "mission": mission,
+        "split": "within-mission",
+        "test_size": args.test_size,
+        "seed": args.seed,
+        "ensemble": args.ensemble,
+        "device": args.device,
+        "oversample": oversample_used,
+        "recall_target": args.recall_target,
+    }
 
-    metrics_text = _format_metrics_text(
-        roc_auc,
-        pr_auc,
-        precision,
-        recall,
-        f1,
-        support if support is not None else positive_support,
-        confusion,
-        test_size,
-        seed,
+    export_dir = artifacts_dir / "exports_within" / mission
+    export_dir.mkdir(parents=True, exist_ok=True)
+    metrics_json_path = export_dir / f"metrics_within-{mission}.json"
+    save_metrics(metrics, metrics_json_path)
+    metrics_text_path = export_dir / f"metrics_within-{mission}.txt"
+    _write_text(_format_metrics_text(metrics, args.test_size, args.seed), metrics_text_path)
+    logger.info("Wrote metrics to %s and %s", metrics_json_path, metrics_text_path)
+
+    recommended = metrics.get("recommended_threshold")
+    thresholds = dict(base_thresholds)
+    if (
+        recommended is not None
+        and not args.keep_default_thresholds
+        and isinstance(recommended, dict)
+        and recommended.get("threshold") is not None
+    ):
+        calibrated_value = float(recommended["threshold"])
+        planet_threshold = thresholds.get("planet", 0.95)
+        thresholds["candidate"] = min(calibrated_value, planet_threshold)
+        logger.info(
+            "Using calibrated candidate threshold %.4f for mission %s (recall target %.2f)",
+            thresholds["candidate"],
+            mission,
+            args.recall_target,
+        )
+    elif recommended is None or not isinstance(recommended, dict):
+        logger.warning("No calibrated threshold available for mission %s", mission)
+    elif args.keep_default_thresholds:
+        logger.info(
+            "Calibrated threshold %.4f ignored due to --keep-default-thresholds", recommended.get("threshold")
+        )
+
+    final_pipeline, _ = _fit_with_optional_oversample(
+        numeric_cols,
+        categorical_cols,
+        features,
+        labels,
+        args=args,
+        logger=logger,
     )
 
     models_dir = artifacts_dir / "models_within"
     models_dir.mkdir(parents=True, exist_ok=True)
     model_path = models_dir / f"model_within-{mission}.pkl"
-    joblib.dump(pipeline, model_path)
+    joblib.dump(final_pipeline, model_path)
     logger.info("Saved model to %s", model_path)
 
     schema_path = models_dir / f"feature_columns_within-{mission}.json"
-    save_feature_schema(X_train.columns, schema_path)
+    save_feature_schema(features.columns, schema_path)
     logger.info("Saved feature schema to %s", schema_path)
 
-    export_dir = artifacts_dir / "exports_within" / mission
-    export_dir.mkdir(parents=True, exist_ok=True)
-    metrics_path = export_dir / f"metrics_within-{mission}.txt"
-    _write_text(metrics_text, metrics_path)
-    logger.info("Wrote metrics to %s", metrics_path)
-
-    proba_full = pipeline.predict_proba(features)[:, 1]
+    proba_full = final_pipeline.predict_proba(features)[:, 1]
     base_predictions = pd.DataFrame(
         {
             "object_id": metadata["object_id"].values,
@@ -386,8 +575,10 @@ def process_mission(
         combined,
         mission,
         thresholds,
-        test_size,
-        seed,
+        base_thresholds,
+        metrics,
+        args.test_size,
+        args.seed,
         int(join_missing),
         len(combined),
     )
@@ -409,10 +600,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     for mission in missions:
         process_mission(
             mission,
-            args.data_dir,
+            args,
             args.artifacts_dir,
-            args.test_size,
-            args.seed,
             thresholds,
             logger,
         )


### PR DESCRIPTION
## Summary
- default the within-mission export workflow to use balanced oversampling, while gracefully falling back if imbalanced-learn is unavailable
- compute recall-targeted thresholds during the within-mission split, persist both JSON and text metrics, and automatically reuse calibrated candidate cutoffs unless disabled
- refresh the README to document the enhanced within-mission behaviour and new CLI controls

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e22b0c0b048326808b2a6eb1043395