### PR TITLE
Ensure calibrated thresholds preserve candidate bucket and add rebuild instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
 In this repository we are developing a deep learning model to detect and classify exoplanets. # AstroVision
+
+## Recent pipeline enhancements
+
+- **Balanced training** – the `exo_tabular` training commands now weight each sample inversely to its class frequency, helping the classifier pay more attention to the rare confirmed exoplanets.
+- **Optional oversampling** – pass `--oversample` to `python -m src.exo_tabular ...` or `python -m src.export_predictions ...` to duplicate minority-class examples with an internal `RandomOverSampler` (requires `imbalanced-learn`).
+- **Calibrated thresholds** – provide a target recall via `--recall-target` (default `0.6`). The training reports (`metrics_*.json`) include a recommended probability threshold that achieves at least that recall, and prediction modes can consume it with `--use-calibrated-buckets`/`--use-calibrated-thresholds` to adjust the candidate bucket.
+- **Within-mission exports** – `python -m src.export_within_mission ...` now oversamples the positive class by default, records calibrated candidate thresholds that hit the desired recall, saves both JSON and text metric reports, and uses the calibrated threshold automatically unless `--keep-default-thresholds` is provided.
+- **Safe threshold fallback** – when a calibrated candidate cutoff is greater than or equal to the planet threshold (e.g., when the model cannot reach the requested recall before hitting 0.95), the tooling automatically keeps the default candidate threshold so that the candidate bucket never collapses.
+
+## Rebuilding metrics, charts and exports
+
+After installing the project requirements (and optionally `imbalanced-learn`), the following commands recreate the key artifacts from scratch. They assume you are in the repository root.
+
+1. **Clean existing artifacts (optional but recommended):**
+   ```bash
+   rm -rf artifacts/*
+   ```
+
+2. **Cross-mission training (produces ROC/PR/confusion PNGs & metrics JSON):**
+   ```bash
+   for mission in tess k2 kepler; do
+     python -m src.exo_tabular \
+       --mode train \
+       --split cross-mission \
+       --test-mission "$mission" \
+       --device cpu \
+       --oversample \
+       --recall-target 0.6
+   done
+   ```
+
+3. **Cross-mission predictions with calibrated buckets:**
+   ```bash
+   for mission in tess k2 kepler; do
+     python -m src.exo_tabular \
+       --mode predict \
+       --split cross-mission \
+       --test-mission "$mission" \
+       --use-calibrated-buckets
+   done
+   ```
+
+4. **Automated export pipeline (optional convenience wrapper):**
+   ```bash
+   python -m src.export_predictions \
+     --data-dir ./data \
+     --artifacts-dir ./artifacts \
+     --runs cross-mission \
+     --oversample \
+     --recall-target 0.6 \
+     --use-calibrated-thresholds
+   ```
+
+5. **Within-mission exports (70/30 split, metrics + CSVs):**
+   ```bash
+   python -m src.export_within_mission \
+     --data-dir ./data \
+     --artifacts-dir ./artifacts \
+     --missions kepler k2 tess \
+     --test-size 0.30 \
+     --seed 42 \
+     --threshold-planet 0.95 \
+     --threshold-candidate 0.50
+   ```
+
+Each command logs the selected thresholds, saves the confusion matrix/curve charts, and drops mission-specific CSVs (planets, candidates, non-planets, discrepancy tables) into the `artifacts/` tree.
+
+Make sure `imbalanced-learn` is installed to enable the oversampling option:
+
+```bash
+pip install imbalanced-learn
+```

--- a/src/exo_tabular.py
+++ b/src/exo_tabular.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from pathlib import Path
@@ -73,8 +74,20 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     parser.add_argument("--test-mission", choices=["tess", "kepler", "k2"], default="tess")
     parser.add_argument("--mission", choices=["kepler", "k2", "tess"], help="Mission for group-kfold mode")
     parser.add_argument("--ensemble", action="store_true", help="Enable stacking ensemble")
+    parser.add_argument("--oversample", action="store_true", help="Apply RandomOverSampler during training")
     parser.add_argument("--device", choices=["cpu", "gpu"], default="cpu")
     parser.add_argument("--random-state", type=int, default=DEFAULT_RANDOM_STATE)
+    parser.add_argument(
+        "--recall-target",
+        type=float,
+        default=0.6,
+        help="Recall target used to calibrate decision threshold",
+    )
+    parser.add_argument(
+        "--use-calibrated-buckets",
+        action="store_true",
+        help="When predicting, use the calibrated threshold for candidate bucket",
+    )
     return parser.parse_args(list(argv))
 
 
@@ -99,16 +112,41 @@ def log_feature_set(features: pd.DataFrame, logger: logging.Logger) -> None:
     logger.info("Feature columns: %s", columns)
 
 
-def assign_bucket(probabilities: np.ndarray) -> List[str]:
+def assign_bucket(probabilities: np.ndarray, *, thresholds: Optional[Dict[str, float]] = None) -> List[str]:
+    if thresholds is None:
+        thresholds = {"planet": 0.95, "candidate": 0.5}
+    planet_th = thresholds.get("planet", 0.95)
+    candidate_th = thresholds.get("candidate", 0.5)
+    if candidate_th >= planet_th:
+        candidate_th = max(0.0, min(candidate_th, planet_th - 1e-6))
     buckets: List[str] = []
     for value in probabilities:
-        if value >= 0.95:
+        if value >= planet_th:
             buckets.append("planet")
-        elif value >= 0.5:
+        elif value >= candidate_th:
             buckets.append("candidate")
         else:
             buckets.append("non-planet")
     return buckets
+
+
+def _load_calibrated_threshold(metrics_path: Path) -> Optional[float]:
+    if not metrics_path.exists():
+        return None
+    try:
+        data = json.loads(metrics_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    recommended = data.get("recommended_threshold")
+    if not isinstance(recommended, dict):
+        return None
+    value = recommended.get("threshold")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def build_artifact_paths(artifacts_dir: Path, mode_tag: str) -> Dict[str, Path]:
@@ -146,7 +184,9 @@ def _train_cross_mission_core(
     *,
     device: str,
     ensemble: bool,
+    oversample: bool,
     random_state: int,
+    recall_target: float,
     logger: logging.Logger,
 ) -> Path:
     train_dataset, test_dataset = load_cross_mission_split(test_mission, data_dir, logger)
@@ -166,15 +206,23 @@ def _train_cross_mission_core(
         ensemble=ensemble,
         logger=logger,
         random_state=random_state,
+        builder_kwargs={"oversample": oversample},
     )
     proba = pipeline.predict_proba(X_test)[:, 1]
-    metrics = evaluate_binary_classification(y_test, proba, thresholds=(0.5, 0.95))
+    metrics = evaluate_binary_classification(
+        y_test,
+        proba,
+        thresholds=(0.5, 0.95),
+        recall_target=recall_target,
+    )
     metrics["configuration"] = {
         "mode": "train",
         "split": "cross-mission",
         "test_mission": test_mission,
         "ensemble": ensemble,
         "device": device,
+        "oversample": oversample,
+        "recall_target": recall_target,
     }
     if "metrics" in artifacts:
         save_metrics(metrics, artifacts["metrics"])
@@ -203,7 +251,9 @@ def train_cross_mission(
     *,
     device: str = "cpu",
     ensemble: bool = False,
+    oversample: bool = False,
     random_state: int = DEFAULT_RANDOM_STATE,
+    recall_target: float = 0.6,
     logger: Optional[logging.Logger] = None,
 ) -> Path:
     logger = logger or logging.getLogger("exo_tabular")
@@ -215,7 +265,9 @@ def train_cross_mission(
         artifacts,
         device=device,
         ensemble=ensemble,
+        oversample=oversample,
         random_state=random_state,
+        recall_target=recall_target,
         logger=logger,
     )
 
@@ -316,9 +368,15 @@ def train_group_kfold(
             ensemble=args.ensemble,
             logger=logger,
             random_state=args.random_state + fold,
+            builder_kwargs={"oversample": args.oversample},
         )
         proba[val_idx] = fold_pipeline.predict_proba(X.iloc[val_idx])[:, 1]
-    metrics = evaluate_binary_classification(y, proba, thresholds=(0.5, 0.95))
+    metrics = evaluate_binary_classification(
+        y,
+        proba,
+        thresholds=(0.5, 0.95),
+        recall_target=args.recall_target,
+    )
     metrics["configuration"] = {
         "mode": "train",
         "split": args.split,
@@ -326,6 +384,8 @@ def train_group_kfold(
         "ensemble": args.ensemble,
         "device": args.device,
         "folds": GROUP_KFOLD_SPLITS,
+        "oversample": args.oversample,
+        "recall_target": args.recall_target,
     }
     save_metrics(metrics, artifacts["metrics"])
     plot_roc_curve(y, proba, artifacts["roc"])
@@ -341,6 +401,7 @@ def train_group_kfold(
         ensemble=args.ensemble,
         logger=logger,
         random_state=args.random_state,
+        builder_kwargs={"oversample": args.oversample},
     )
     joblib.dump(final_pipeline, artifacts["model"])
     save_feature_schema(X.columns, artifacts["schema"])
@@ -363,7 +424,37 @@ def predict_dataset(
             schema_path=schema_path,
             logger=logger,
         )
-        predictions["bucket"] = assign_bucket(predictions["proba_planet"].to_numpy())
+        thresholds = {"planet": 0.95, "candidate": 0.5}
+        if args.use_calibrated_buckets:
+            calibrated = _load_calibrated_threshold(artifacts["metrics"])
+            if calibrated is not None:
+                if calibrated >= thresholds["planet"]:
+                    logger.warning(
+                        (
+                            "Calibrated candidate threshold %.4f for mission %s is >= planet "
+                            "threshold %.2f; keeping candidate threshold %.2f"
+                        ),
+                        calibrated,
+                        args.test_mission,
+                        thresholds["planet"],
+                        thresholds["candidate"],
+                    )
+                else:
+                    thresholds["candidate"] = calibrated
+                    logger.info(
+                        "Using calibrated candidate threshold %.4f for mission %s",
+                        calibrated,
+                        args.test_mission,
+                    )
+            else:
+                logger.warning(
+                    "Calibrated threshold requested but not found at %s",
+                    artifacts["metrics"],
+                )
+        predictions["bucket"] = assign_bucket(
+            predictions["proba_planet"].to_numpy(),
+            thresholds=thresholds,
+        )
     else:
         if not model_path.exists():
             raise FileNotFoundError(f"Trained model not found at {model_path}")
@@ -378,12 +469,39 @@ def predict_dataset(
         features = align_to_schema(target_dataset.features, schema)
         log_feature_set(features, logger)
         proba = pipeline.predict_proba(features)[:, 1]
+        thresholds = {"planet": 0.95, "candidate": 0.5}
+        if args.use_calibrated_buckets:
+            calibrated = _load_calibrated_threshold(artifacts["metrics"])
+            if calibrated is not None:
+                if calibrated >= thresholds["planet"]:
+                    logger.warning(
+                        (
+                            "Calibrated candidate threshold %.4f for mission %s is >= planet "
+                            "threshold %.2f; keeping candidate threshold %.2f"
+                        ),
+                        calibrated,
+                        args.mission,
+                        thresholds["planet"],
+                        thresholds["candidate"],
+                    )
+                else:
+                    thresholds["candidate"] = calibrated
+                    logger.info(
+                        "Using calibrated candidate threshold %.4f for mission %s",
+                        calibrated,
+                        args.mission,
+                    )
+            else:
+                logger.warning(
+                    "Calibrated threshold requested but not found at %s",
+                    artifacts["metrics"],
+                )
         predictions = pd.DataFrame(
             {
                 "object_id": target_dataset.metadata["object_id"].values,
                 "mission": target_dataset.metadata["mission"].values,
                 "proba_planet": proba,
-                "bucket": assign_bucket(proba),
+                "bucket": assign_bucket(proba, thresholds=thresholds),
             }
         )
         for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
@@ -414,7 +532,9 @@ def main(argv: Iterable[str]) -> None:
                 artifacts,
                 device=args.device,
                 ensemble=args.ensemble,
+                oversample=args.oversample,
                 random_state=args.random_state,
+                recall_target=args.recall_target,
                 logger=logger,
             )
         else:

--- a/src/export_predictions.py
+++ b/src/export_predictions.py
@@ -14,9 +14,10 @@ Usage example::
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
 
@@ -38,6 +39,18 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     parser.add_argument("--device", choices=["cpu", "gpu"], default="cpu")
     parser.add_argument("--ensemble", action="store_true", help="Enable ensemble training")
     parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--oversample", action="store_true", help="Apply RandomOverSampler during training")
+    parser.add_argument(
+        "--recall-target",
+        type=float,
+        default=0.6,
+        help="Recall target used to calibrate thresholds",
+    )
+    parser.add_argument(
+        "--use-calibrated-thresholds",
+        action="store_true",
+        help="Override candidate threshold with calibrated value saved in metrics",
+    )
     return parser.parse_args(list(argv))
 
 
@@ -90,6 +103,25 @@ def _write_summary(
     path.write_text("\n".join(lines))
 
 
+def _load_calibrated_threshold(metrics_path: Path) -> Optional[float]:
+    if not metrics_path.exists():
+        return None
+    try:
+        data = json.loads(metrics_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    recommended = data.get("recommended_threshold")
+    if not isinstance(recommended, dict):
+        return None
+    value = recommended.get("threshold")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _prepare_predictions(
     mission: str,
     predictions: pd.DataFrame,
@@ -125,7 +157,7 @@ def run_cross_mission(args: argparse.Namespace) -> None:
     logger = logging.getLogger("export_predictions")
     data_dir = args.data_dir
     artifacts_dir = args.artifacts_dir
-    thresholds = {"planet": args.threshold_planet, "candidate": args.threshold_candidate}
+    base_thresholds = {"planet": args.threshold_planet, "candidate": args.threshold_candidate}
     missions = ["tess", "k2", "kepler"]
 
     for mission in missions:
@@ -136,7 +168,9 @@ def run_cross_mission(args: argparse.Namespace) -> None:
             artifacts_dir,
             device=args.device,
             ensemble=args.ensemble,
+            oversample=args.oversample,
             random_state=args.random_state,
+            recall_target=args.recall_target,
             logger=logger,
         )
         logger.info("Predicting mission %s", mission)
@@ -148,7 +182,35 @@ def run_cross_mission(args: argparse.Namespace) -> None:
             logger=logger,
         )
         _log_join_gaps(predictions, mission, logger)
-        prepared = _prepare_predictions(mission, predictions, thresholds)
+        mission_thresholds = dict(base_thresholds)
+        if args.use_calibrated_thresholds:
+            metrics_path = artifacts_dir / f"metrics_{mission}.json"
+            calibrated = _load_calibrated_threshold(metrics_path)
+            if calibrated is not None:
+                if calibrated >= mission_thresholds["planet"]:
+                    logger.warning(
+                        (
+                            "Calibrated candidate threshold %.4f for mission %s is >= planet "
+                            "threshold %.2f; keeping candidate threshold %.2f"
+                        ),
+                        calibrated,
+                        mission,
+                        mission_thresholds["planet"],
+                        mission_thresholds["candidate"],
+                    )
+                else:
+                    mission_thresholds["candidate"] = calibrated
+                    logger.info(
+                        "Using calibrated candidate threshold %.4f for mission %s",
+                        calibrated,
+                        mission,
+                    )
+            else:
+                logger.warning(
+                    "Calibrated threshold requested but metrics file missing or invalid at %s",
+                    metrics_path,
+                )
+        prepared = _prepare_predictions(mission, predictions, mission_thresholds)
         export_dir = artifacts_dir / "exports" / mission
         export_dir.mkdir(parents=True, exist_ok=True)
         ordered_columns = [
@@ -211,7 +273,7 @@ def run_cross_mission(args: argparse.Namespace) -> None:
             _write_csv(subset_out, export_dir / filename)
 
         summary_path = export_dir / f"summary_{mission}.txt"
-        _write_summary(prepared, thresholds, summary_path)
+        _write_summary(prepared, mission_thresholds, summary_path)
         logger.info("Finished exports for mission %s", mission)
 
 

--- a/src/export_within_mission.py
+++ b/src/export_within_mission.py
@@ -22,14 +22,7 @@ from pathlib import Path
 from typing import Iterable, List, Sequence
 
 import joblib
-import numpy as np
 import pandas as pd
-from sklearn.metrics import (
-    average_precision_score,
-    confusion_matrix,
-    precision_recall_fscore_support,
-    roc_auc_score,
-)
 from sklearn.model_selection import StratifiedShuffleSplit
 
 if __package__ in (None, ""):
@@ -39,7 +32,12 @@ if __package__ in (None, ""):
         nasa_bucket,
         save_feature_schema,
     )
-    from modeling import build_lightgbm_pipeline
+    from modeling import (
+        build_pipeline,
+        evaluate_binary_classification,
+        fit_pipeline_with_fallback,
+        save_metrics,
+    )
 else:
     from .dataio import (
         infer_feature_types,
@@ -47,7 +45,12 @@ else:
         nasa_bucket,
         save_feature_schema,
     )
-    from .modeling import build_lightgbm_pipeline
+    from .modeling import (
+        build_pipeline,
+        evaluate_binary_classification,
+        fit_pipeline_with_fallback,
+        save_metrics,
+    )
 
 
 PHYSICAL_EXPORT_COLUMNS: Sequence[str] = (
@@ -92,6 +95,26 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--threshold-planet", type=float, default=0.95)
     parser.add_argument("--threshold-candidate", type=float, default=0.50)
+    parser.add_argument("--device", choices=["cpu", "gpu"], default="cpu")
+    parser.add_argument("--ensemble", action="store_true", help="Enable stacking ensemble")
+    parser.add_argument(
+        "--recall-target",
+        type=float,
+        default=0.6,
+        help="Recall target used to calibrate candidate threshold",
+    )
+    parser.add_argument(
+        "--keep-default-thresholds",
+        action="store_true",
+        help="Use provided thresholds even if calibrated values are available",
+    )
+    parser.add_argument(
+        "--no-oversample",
+        dest="oversample",
+        action="store_false",
+        help="Disable RandomOverSampler augmentation (enabled by default)",
+    )
+    parser.set_defaults(oversample=True)
     return parser.parse_args(list(argv))
 
 
@@ -121,31 +144,76 @@ def _select_missions(raw: Sequence[str] | None) -> List[str]:
     return normalized
 
 
-def _format_metrics_text(
-    roc_auc: float,
-    pr_auc: float,
-    precision: float,
-    recall: float,
-    f1: float,
-    support: float | None,
-    confusion: np.ndarray,
-    test_size: float,
-    seed: int,
-) -> str:
-    lines = [
-        f"ROC-AUC: {roc_auc:.4f}",
-        f"PR-AUC: {pr_auc:.4f}",
-        f"Precision (threshold=0.5): {precision:.4f}",
-        f"Recall (threshold=0.5): {recall:.4f}",
-        f"F1 (threshold=0.5): {f1:.4f}",
-        f"Support (positive class): {int(support) if support is not None else 'n/a'}",
-        "",
-        "Confusion matrix (threshold=0.5):",
-        str(confusion),
-        "",
-        f"Test size: {test_size}",
-        f"Seed: {seed}",
-    ]
+def _format_metrics_text(metrics: dict[str, object], test_size: float, seed: int) -> str:
+    lines: List[str] = []
+    roc_auc = metrics.get("roc_auc")
+    pr_auc = metrics.get("pr_auc")
+    positive_rate = metrics.get("positive_rate")
+    if roc_auc is not None:
+        lines.append(f"ROC-AUC: {roc_auc:.4f}")
+    if pr_auc is not None:
+        lines.append(f"PR-AUC: {pr_auc:.4f}")
+    if positive_rate is not None:
+        lines.append(f"Positive rate: {positive_rate:.4f}")
+    lines.append("")
+    lines.append("Threshold metrics:")
+    threshold_metrics = metrics.get("thresholds", {})
+    ordered_keys: List[str] = []
+    numeric_keys = [k for k in threshold_metrics.keys() if k not in {"calibrated"}]
+    ordered_keys.extend(sorted(numeric_keys, key=float))
+    if "calibrated" in threshold_metrics:
+        ordered_keys.append("calibrated")
+    def _fmt_float(value: object) -> str:
+        if value is None:
+            return "nan"
+        try:
+            return f"{float(value):.4f}"
+        except (TypeError, ValueError):
+            return "nan"
+
+    def _fmt_int(value: object) -> str:
+        if value is None:
+            return "n/a"
+        try:
+            return str(int(value))
+        except (TypeError, ValueError):
+            return "n/a"
+
+    for key in ordered_keys:
+        values = threshold_metrics.get(key, {})
+        label = "calibrated" if key == "calibrated" else f"threshold={float(key):.2f}"
+        precision = _fmt_float(values.get("precision"))
+        recall = _fmt_float(values.get("recall"))
+        f1 = _fmt_float(values.get("f1"))
+        predicted = _fmt_int(values.get("predicted_positive"))
+        lines.append(
+            f"  {label}: precision={precision} recall={recall} f1={f1} predicted_positive={predicted}"
+        )
+    lines.append("")
+    confusion = metrics.get("confusion_matrix", {})
+    tn = confusion.get("tn", 0)
+    fp = confusion.get("fp", 0)
+    fn = confusion.get("fn", 0)
+    tp = confusion.get("tp", 0)
+    lines.append("Confusion matrix (threshold=0.5):")
+    lines.append(f"  [[TN={tn}, FP={fp}], [FN={fn}, TP={tp}]]")
+    lines.append("")
+    lines.append(f"Test size: {test_size}")
+    lines.append(f"Seed: {seed}")
+    recommended = metrics.get("recommended_threshold")
+    if isinstance(recommended, dict):
+        th = _fmt_float(recommended.get("threshold"))
+        rec = _fmt_float(recommended.get("recall"))
+        prec = _fmt_float(recommended.get("precision"))
+        f1 = _fmt_float(recommended.get("f1"))
+        lines.append("")
+        lines.append(
+            "Recommended threshold: "
+            f"threshold={th} precision={prec} recall={rec} f1={f1}"
+        )
+        target = recommended.get("recall_target")
+        if target is not None:
+            lines.append(f"Recall target: {target:.2f}")
     return "\n".join(lines)
 
 
@@ -203,10 +271,57 @@ def _write_text(content: str, path: Path) -> None:
     path.write_text(content)
 
 
+def _fit_with_optional_oversample(
+    numeric_cols: Sequence[str],
+    categorical_cols: Sequence[str],
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    args: argparse.Namespace,
+    logger: logging.Logger,
+) -> tuple[object, bool]:
+    try:
+        pipeline = fit_pipeline_with_fallback(
+            build_pipeline,
+            numeric_cols,
+            categorical_cols,
+            X,
+            y,
+            device=args.device,
+            ensemble=args.ensemble,
+            logger=logger,
+            random_state=args.seed,
+            builder_kwargs={"oversample": args.oversample},
+        )
+        return pipeline, args.oversample
+    except ImportError as exc:
+        if args.oversample:
+            logger.warning(
+                "Oversampling requested but unavailable (%s). Continuing without RandomOverSampler.",
+                exc,
+            )
+            pipeline = fit_pipeline_with_fallback(
+                build_pipeline,
+                numeric_cols,
+                categorical_cols,
+                X,
+                y,
+                device=args.device,
+                ensemble=args.ensemble,
+                logger=logger,
+                random_state=args.seed,
+                builder_kwargs={"oversample": False},
+            )
+            return pipeline, False
+        raise
+
+
 def _build_summary(
     df: pd.DataFrame,
     mission: str,
     thresholds: dict[str, float],
+    base_thresholds: dict[str, float],
+    metrics: dict[str, object],
     test_size: float,
     seed: int,
     join_missing: int,
@@ -236,9 +351,51 @@ def _build_summary(
     lines.append("Prediction vs NASA category matrix:")
     lines.append(matrix.fillna(0).astype(int).to_string())
     lines.append("")
-    lines.append("Thresholds:")
+    lines.append("Thresholds used for export:")
     for key, value in thresholds.items():
         lines.append(f"  {key}: {value}")
+    lines.append("")
+    lines.append("Base thresholds requested:")
+    for key, value in base_thresholds.items():
+        lines.append(f"  {key}: {value}")
+    recommended = metrics.get("recommended_threshold")
+    if isinstance(recommended, dict):
+        lines.append("")
+        lines.append("Calibrated candidate threshold (recall target):")
+        lines.append(
+            "  threshold={threshold:.4f} precision={precision:.4f} recall={recall:.4f} f1={f1:.4f} target={target}".format(
+                threshold=float(recommended.get("threshold", float("nan"))),
+                precision=float(recommended.get("precision", float("nan"))),
+                recall=float(recommended.get("recall", float("nan"))),
+                f1=float(recommended.get("f1", float("nan"))),
+                target=recommended.get("recall_target", "n/a"),
+            )
+        )
+    lines.append("")
+    lines.append("Holdout metrics (threshold=0.50):")
+    threshold_metrics = metrics.get("thresholds", {}).get("0.5", {})
+    lines.append(
+        "  precision={precision:.4f} recall={recall:.4f} f1={f1:.4f} predicted_positive={predicted}".format(
+            precision=float(threshold_metrics.get("precision", float("nan"))),
+            recall=float(threshold_metrics.get("recall", float("nan"))),
+            f1=float(threshold_metrics.get("f1", float("nan"))),
+            predicted=int(threshold_metrics.get("predicted_positive", 0)),
+        )
+    )
+    lines.append("  confusion_matrix=[[{tn}, {fp}], [{fn}, {tp}]]".format(**{
+        "tn": metrics.get("confusion_matrix", {}).get("tn", 0),
+        "fp": metrics.get("confusion_matrix", {}).get("fp", 0),
+        "fn": metrics.get("confusion_matrix", {}).get("fn", 0),
+        "tp": metrics.get("confusion_matrix", {}).get("tp", 0),
+    }))
+    lines.append("")
+    lines.append(
+        "ROC-AUC={roc:.4f} PR-AUC={pr:.4f} positive_rate={pos:.4f}".format(
+            roc=float(metrics.get("roc_auc", float("nan"))),
+            pr=float(metrics.get("pr_auc", float("nan"))),
+            pos=float(metrics.get("positive_rate", float("nan"))),
+        )
+    )
     lines.append("")
     lines.append(f"Test size: {test_size}")
     lines.append(f"Seed: {seed}")
@@ -263,20 +420,18 @@ def _export_diffs(df: pd.DataFrame, export_dir: Path, mission: str) -> None:
 
 def process_mission(
     mission: str,
-    data_dir: Path,
+    args: argparse.Namespace,
     artifacts_dir: Path,
-    test_size: float,
-    seed: int,
-    thresholds: dict[str, float],
+    base_thresholds: dict[str, float],
     logger: logging.Logger,
 ) -> None:
     logger.info("Processing mission %s", mission)
-    dataset = load_mission_dataset(mission, data_dir, logger)
+    dataset = load_mission_dataset(mission, args.data_dir, logger)
     features = dataset.features
     labels = dataset.labels
     metadata = dataset.metadata
 
-    splitter = StratifiedShuffleSplit(n_splits=1, test_size=test_size, random_state=seed)
+    splitter = StratifiedShuffleSplit(n_splits=1, test_size=args.test_size, random_state=args.seed)
     train_indices, test_indices = next(splitter.split(features, labels))
     X_train = features.iloc[train_indices].copy()
     y_train = labels.iloc[train_indices].copy()
@@ -286,59 +441,105 @@ def process_mission(
         "Mission %s: %d train samples, %d test samples", mission, X_train.shape[0], X_test.shape[0]
     )
 
-    numeric_cols, categorical_cols = infer_feature_types(X_train)
+    numeric_cols, categorical_cols = infer_feature_types(features)
     logger.info(
         "Mission %s: %d numeric features, %d categorical features",
         mission,
         len(numeric_cols),
         len(categorical_cols),
     )
-    pipeline = build_lightgbm_pipeline(numeric_cols, categorical_cols, random_state=seed)
-    logger.info("Training LightGBM pipeline on CPU for mission %s", mission)
-    pipeline.fit(X_train, y_train)
+
+    pipeline, oversample_used = _fit_with_optional_oversample(
+        numeric_cols,
+        categorical_cols,
+        X_train,
+        y_train,
+        args=args,
+        logger=logger,
+    )
 
     proba_test = pipeline.predict_proba(X_test)[:, 1]
-    predictions_test = (proba_test >= 0.5).astype(int)
-    roc_auc = roc_auc_score(y_test, proba_test)
-    pr_auc = average_precision_score(y_test, proba_test)
-    precision, recall, f1, support = precision_recall_fscore_support(
+    metrics = evaluate_binary_classification(
         y_test,
-        predictions_test,
-        average="binary",
-        zero_division=0,
+        proba_test,
+        thresholds=(0.5, 0.95),
+        recall_target=args.recall_target,
     )
-    confusion = confusion_matrix(y_test, predictions_test)
-    positive_support = int((y_test == 1).sum())
+    metrics["configuration"] = {
+        "mission": mission,
+        "split": "within-mission",
+        "test_size": args.test_size,
+        "seed": args.seed,
+        "ensemble": args.ensemble,
+        "device": args.device,
+        "oversample": oversample_used,
+        "recall_target": args.recall_target,
+    }
 
-    metrics_text = _format_metrics_text(
-        roc_auc,
-        pr_auc,
-        precision,
-        recall,
-        f1,
-        support if support is not None else positive_support,
-        confusion,
-        test_size,
-        seed,
+    export_dir = artifacts_dir / "exports_within" / mission
+    export_dir.mkdir(parents=True, exist_ok=True)
+    metrics_json_path = export_dir / f"metrics_within-{mission}.json"
+    save_metrics(metrics, metrics_json_path)
+    metrics_text_path = export_dir / f"metrics_within-{mission}.txt"
+    _write_text(_format_metrics_text(metrics, args.test_size, args.seed), metrics_text_path)
+    logger.info("Wrote metrics to %s and %s", metrics_json_path, metrics_text_path)
+
+    recommended = metrics.get("recommended_threshold")
+    thresholds = dict(base_thresholds)
+    if (
+        recommended is not None
+        and not args.keep_default_thresholds
+        and isinstance(recommended, dict)
+        and recommended.get("threshold") is not None
+    ):
+        calibrated_value = float(recommended["threshold"])
+        planet_threshold = thresholds.get("planet", 0.95)
+        if calibrated_value >= planet_threshold:
+            logger.warning(
+                (
+                    "Calibrated candidate threshold %.4f for mission %s is >= planet threshold %.2f; "
+                    "keeping candidate threshold %.2f"
+                ),
+                calibrated_value,
+                mission,
+                planet_threshold,
+                thresholds["candidate"],
+            )
+        else:
+            thresholds["candidate"] = calibrated_value
+            logger.info(
+                "Using calibrated candidate threshold %.4f for mission %s (recall target %.2f)",
+                thresholds["candidate"],
+                mission,
+                args.recall_target,
+            )
+    elif recommended is None or not isinstance(recommended, dict):
+        logger.warning("No calibrated threshold available for mission %s", mission)
+    elif args.keep_default_thresholds:
+        logger.info(
+            "Calibrated threshold %.4f ignored due to --keep-default-thresholds", recommended.get("threshold")
+        )
+
+    final_pipeline, _ = _fit_with_optional_oversample(
+        numeric_cols,
+        categorical_cols,
+        features,
+        labels,
+        args=args,
+        logger=logger,
     )
 
     models_dir = artifacts_dir / "models_within"
     models_dir.mkdir(parents=True, exist_ok=True)
     model_path = models_dir / f"model_within-{mission}.pkl"
-    joblib.dump(pipeline, model_path)
+    joblib.dump(final_pipeline, model_path)
     logger.info("Saved model to %s", model_path)
 
     schema_path = models_dir / f"feature_columns_within-{mission}.json"
-    save_feature_schema(X_train.columns, schema_path)
+    save_feature_schema(features.columns, schema_path)
     logger.info("Saved feature schema to %s", schema_path)
 
-    export_dir = artifacts_dir / "exports_within" / mission
-    export_dir.mkdir(parents=True, exist_ok=True)
-    metrics_path = export_dir / f"metrics_within-{mission}.txt"
-    _write_text(metrics_text, metrics_path)
-    logger.info("Wrote metrics to %s", metrics_path)
-
-    proba_full = pipeline.predict_proba(features)[:, 1]
+    proba_full = final_pipeline.predict_proba(features)[:, 1]
     base_predictions = pd.DataFrame(
         {
             "object_id": metadata["object_id"].values,
@@ -386,8 +587,10 @@ def process_mission(
         combined,
         mission,
         thresholds,
-        test_size,
-        seed,
+        base_thresholds,
+        metrics,
+        args.test_size,
+        args.seed,
         int(join_missing),
         len(combined),
     )
@@ -409,10 +612,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     for mission in missions:
         process_mission(
             mission,
-            args.data_dir,
+            args,
             args.artifacts_dir,
-            args.test_size,
-            args.seed,
             thresholds,
             logger,
         )


### PR DESCRIPTION
## Summary
- guard against calibrated candidate thresholds that exceed the planet cutoff so candidates remain populated
- keep the default candidate threshold when calibration is unusable across CLI, export, and within-mission utilities
- document full command sequences for regenerating metrics, charts, and exports, including the threshold fallback behaviour

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e22b0c0b048326808b2a6eb1043395