### PR TITLE
Handle percentage thresholds for candidate bucketing

### DIFF
--- a/src/exo_tabular.py
+++ b/src/exo_tabular.py
@@ -112,11 +112,21 @@ def log_feature_set(features: pd.DataFrame, logger: logging.Logger) -> None:
     logger.info("Feature columns: %s", columns)
 
 
+def _normalize_threshold(value: float) -> float:
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
 def assign_bucket(probabilities: np.ndarray, *, thresholds: Optional[Dict[str, float]] = None) -> List[str]:
     if thresholds is None:
         thresholds = {"planet": 0.95, "candidate": 0.5}
-    planet_th = thresholds.get("planet", 0.95)
-    candidate_th = thresholds.get("candidate", 0.5)
+    planet_th = _normalize_threshold(thresholds.get("planet", 0.95))
+    candidate_th = _normalize_threshold(thresholds.get("candidate", 0.5))
     if candidate_th >= planet_th:
         candidate_th = max(0.0, min(candidate_th, planet_th - 1e-6))
     buckets: List[str] = []


### PR DESCRIPTION
## Summary
- sanitize planet and candidate threshold inputs so values above 1.0 are treated as percentages and clamped to probability bounds
- ensure bucket assignment logic across export scripts uses the normalized thresholds to avoid collapsing the candidate category

## Testing
- python -m py_compile src/export_predictions.py src/export_within_mission.py src/exo_tabular.py

------
https://chatgpt.com/codex/tasks/task_e_68e3180c9754832691dbe17366dfddca