### PR TITLE
Normalize legacy percentage probabilities before bucketing

### DIFF
--- a/src/exo_tabular.py
+++ b/src/exo_tabular.py
@@ -112,15 +112,36 @@ def log_feature_set(features: pd.DataFrame, logger: logging.Logger) -> None:
     logger.info("Feature columns: %s", columns)
 
 
+def _normalize_threshold(value: float) -> float:
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
+def _normalize_probability(value: float) -> float:
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
 def assign_bucket(probabilities: np.ndarray, *, thresholds: Optional[Dict[str, float]] = None) -> List[str]:
     if thresholds is None:
         thresholds = {"planet": 0.95, "candidate": 0.5}
-    planet_th = thresholds.get("planet", 0.95)
-    candidate_th = thresholds.get("candidate", 0.5)
+    planet_th = _normalize_threshold(thresholds.get("planet", 0.95))
+    candidate_th = _normalize_threshold(thresholds.get("candidate", 0.5))
     if candidate_th >= planet_th:
         candidate_th = max(0.0, min(candidate_th, planet_th - 1e-6))
     buckets: List[str] = []
     for value in probabilities:
+        value = _normalize_probability(float(value))
         if value >= planet_th:
             buckets.append("planet")
         elif value >= candidate_th:

--- a/src/export_predictions.py
+++ b/src/export_predictions.py
@@ -58,7 +58,50 @@ def configure_logging() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
+def _normalize_threshold(value: float) -> float:
+    """Convert threshold percentages into probabilities.
+
+    The CLI historically accepted inputs such as ``50`` or ``95`` to express
+    50% and 95%.  Interpreting those literally leads to impossible decision
+    rules (probabilities are in ``[0, 1]``), which in turn collapses the
+    candidate bucket to zero elements.  To make the interface resilient, any
+    value greater than one is treated as a percentage and scaled back to the
+    ``[0, 1]`` interval.
+    """
+
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
+def _normalize_probability(value: float) -> float:
+    """Convert probability percentages into probabilities.
+
+    Some historical prediction exports stored the model score in the ``0-100``
+    range instead of ``0-1``.  When those values are consumed by the newer
+    bucket logic the candidate range collapses because every value ends up
+    greater than the planet threshold.  Detect these legacy percentages and
+    coerce them back into a standard probability."""
+
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
 def bucketize(probability: float, th_planet: float = 0.95, th_candidate: float = 0.50) -> str:
+    th_planet = _normalize_threshold(th_planet)
+    th_candidate = _normalize_threshold(th_candidate)
+    probability = _normalize_probability(probability)
+    if th_candidate >= th_planet:
+        th_candidate = max(0.0, min(th_candidate, th_planet - 1e-6))
     if probability >= th_planet:
         return "planet"
     if probability >= th_candidate:
@@ -128,6 +171,7 @@ def _prepare_predictions(
     thresholds: Dict[str, float],
 ) -> pd.DataFrame:
     df = predictions.copy()
+    df["proba_planet"] = df["proba_planet"].apply(_normalize_probability)
     df["category"] = df["proba_planet"].apply(
         bucketize,
         th_planet=thresholds["planet"],
@@ -157,7 +201,10 @@ def run_cross_mission(args: argparse.Namespace) -> None:
     logger = logging.getLogger("export_predictions")
     data_dir = args.data_dir
     artifacts_dir = args.artifacts_dir
-    base_thresholds = {"planet": args.threshold_planet, "candidate": args.threshold_candidate}
+    base_thresholds = {
+        "planet": _normalize_threshold(args.threshold_planet),
+        "candidate": _normalize_threshold(args.threshold_candidate),
+    }
     missions = ["tess", "k2", "kepler"]
 
     for mission in missions:

--- a/src/export_within_mission.py
+++ b/src/export_within_mission.py
@@ -122,7 +122,32 @@ def configure_logging() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
+def _normalize_threshold(value: float) -> float:
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
+def _normalize_probability(value: float) -> float:
+    if value > 1:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return float(value)
+
+
 def bucketize(probability: float, th_planet: float, th_candidate: float) -> str:
+    th_planet = _normalize_threshold(th_planet)
+    th_candidate = _normalize_threshold(th_candidate)
+    probability = _normalize_probability(probability)
+    if th_candidate >= th_planet:
+        th_candidate = max(0.0, min(th_candidate, th_planet - 1e-6))
     if probability >= th_planet:
         return "planet"
     if probability >= th_candidate:
@@ -548,6 +573,7 @@ def process_mission(
         },
         index=metadata.index,
     )
+    base_predictions["proba_planet"] = base_predictions["proba_planet"].apply(_normalize_probability)
     base_predictions["confidence_pct"] = (base_predictions["proba_planet"] * 100).round(2)
     base_predictions["category"] = base_predictions["proba_planet"].apply(
         bucketize,
@@ -607,7 +633,10 @@ def main(argv: Iterable[str] | None = None) -> None:
     logger = logging.getLogger("export_within_mission")
     missions = _select_missions(args.missions)
     logger.info("Running within-mission export for missions: %s", missions)
-    thresholds = {"planet": args.threshold_planet, "candidate": args.threshold_candidate}
+    thresholds = {
+        "planet": _normalize_threshold(args.threshold_planet),
+        "candidate": _normalize_threshold(args.threshold_candidate),
+    }
 
     for mission in missions:
         process_mission(


### PR DESCRIPTION
## Summary
- normalize incoming probability scores in the export workflows so legacy 0-100 values map back into the 0-1 bucket range
- update bucket helpers to apply the same normalization before comparing against the thresholds
- extend the shared tabular assign_bucket utility to treat percentage-style scores consistently across callers

## Testing
- python -m py_compile src/export_predictions.py src/export_within_mission.py src/exo_tabular.py

------
https://chatgpt.com/codex/tasks/task_e_68e3180c9754832691dbe17366dfddca