### PR TITLE
Add NASA-style multiclass option to tabular pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ In this repository we are developing a deep learning model to detect and classif
 - **Calibrated thresholds** – provide a target recall via `--recall-target` (default `0.6`). The training reports (`metrics_*.json`) include a recommended probability threshold that achieves at least that recall, and prediction modes can consume it with `--use-calibrated-buckets`/`--use-calibrated-thresholds` to adjust the candidate bucket.
 - **Within-mission exports** – `python -m src.export_within_mission ...` now oversamples the positive class by default, records calibrated candidate thresholds that hit the desired recall, saves both JSON and text metric reports, and uses the calibrated threshold automatically unless `--keep-default-thresholds` is provided.
 - **Safe threshold fallback** – when a calibrated candidate cutoff is greater than or equal to the planet threshold (e.g., when the model cannot reach the requested recall before hitting 0.95), the tooling automatically keeps the default candidate threshold so that the candidate bucket never collapses.
+- **NASA-style dispositions** – the tabular pipeline can now learn the three official NASA categories (`planet`, `candidate`, `non-planet`). Set `--label-mode nasa` (the new default) to train a multiclass model or `--label-mode binary` to retain the previous confirmed vs. non-confirmed setup.
+
+> **Tip:** Artifacts are stored under names that include the label mode (for example, `model_tess_nasa.pkl`). Make sure to match the label mode when reloading models or metrics.
 
 ## Rebuilding metrics, charts and exports
 
@@ -24,6 +27,7 @@ After installing the project requirements (and optionally `imbalanced-learn`), t
        --mode train \
        --split cross-mission \
        --test-mission "$mission" \
+       --label-mode nasa \
        --device cpu \
        --oversample \
        --recall-target 0.6
@@ -37,6 +41,7 @@ After installing the project requirements (and optionally `imbalanced-learn`), t
        --mode predict \
        --split cross-mission \
        --test-mission "$mission" \
+       --label-mode nasa \
        --use-calibrated-buckets
    done
    ```

--- a/src/dataio.py
+++ b/src/dataio.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -178,6 +178,8 @@ class MissionDataset:
     features: pd.DataFrame
     labels: pd.Series
     metadata: pd.DataFrame
+    label_mode: str = "binary"
+    class_names: List[str] = field(default_factory=list)
 
 
 def read_mission_csv(path: Path) -> pd.DataFrame:
@@ -200,14 +202,32 @@ def _detect_label_column(mission: str, df: pd.DataFrame) -> str:
     raise ValueError(f"Could not find a label column for mission '{mission}'.")
 
 
-def _map_labels(mission: str, label_series: pd.Series) -> Tuple[pd.Series, pd.Series]:
-    positives = MISSION_POSITIVE_LABELS.get(mission, set())
+def _map_labels(
+    mission: str,
+    label_series: pd.Series,
+    *,
+    label_mode: str = "binary",
+) -> Tuple[pd.Series, pd.Series, Optional[pd.Series]]:
     raw = label_series.astype("string")
     lowered = raw.str.lower().str.strip()
     mask_known = raw.notna() & ~lowered.isin({"", "nan", "none"})
     mapped = pd.Series(np.nan, index=label_series.index, dtype=float)
-    mapped.loc[mask_known] = lowered.loc[mask_known].isin(positives).astype(float)
-    return mapped, raw.fillna("")
+    bucket_labels: Optional[pd.Series] = None
+    if label_mode == "nasa":
+        buckets = raw.fillna("").map(lambda value: nasa_bucket(value, mission))
+        bucket_categories = pd.Categorical(
+            buckets,
+            categories=["non-planet", "candidate", "planet"],
+            ordered=True,
+        )
+        bucket_codes = pd.Series(bucket_categories.codes, index=label_series.index, dtype=float)
+        mapped.loc[mask_known] = bucket_codes.loc[mask_known]
+        mapped.replace({-1.0: np.nan}, inplace=True)
+        bucket_labels = buckets
+    else:
+        positives = MISSION_POSITIVE_LABELS.get(mission, set())
+        mapped.loc[mask_known] = lowered.loc[mask_known].isin(positives).astype(float)
+    return mapped, raw.fillna(""), bucket_labels
 
 
 def _filter_leak_columns(df: pd.DataFrame, logger: logging.Logger) -> pd.DataFrame:
@@ -270,6 +290,8 @@ def _build_metadata(
     df: pd.DataFrame,
     raw_labels: pd.Series,
     canonical_features: Dict[str, pd.Series],
+    *,
+    bucket_labels: Optional[pd.Series] = None,
 ) -> pd.DataFrame:
     metadata = pd.DataFrame(index=df.index)
     metadata["mission"] = mission
@@ -290,6 +312,8 @@ def _build_metadata(
         group_id = metadata["object_id"]
     metadata["group_id"] = group_id.astype(str).fillna("unknown")
     metadata["label_text"] = raw_labels.astype(str)
+    if bucket_labels is not None:
+        metadata["nasa_bucket"] = bucket_labels.astype(str)
     for physical in PHYSICAL_OUTPUT_COLUMNS:
         series = None
         if physical in canonical_features:
@@ -309,7 +333,13 @@ def _append_additional_numeric(features: pd.DataFrame, df: pd.DataFrame) -> pd.D
     return augmented
 
 
-def load_mission_dataset(mission: str, data_dir: Path, logger: Optional[logging.Logger] = None) -> MissionDataset:
+def load_mission_dataset(
+    mission: str,
+    data_dir: Path,
+    logger: Optional[logging.Logger] = None,
+    *,
+    label_mode: str = "binary",
+) -> MissionDataset:
     logger = logger or logging.getLogger(__name__)
     mission_key = mission.lower()
     if mission_key not in MISSION_FILES:
@@ -321,7 +351,11 @@ def load_mission_dataset(mission: str, data_dir: Path, logger: Optional[logging.
     df = read_mission_csv(path)
     df = _standardize_identifiers(df)
     label_col = _detect_label_column(mission_key, df)
-    labels, raw_labels = _map_labels(mission_key, df[label_col])
+    labels, raw_labels, bucket_labels = _map_labels(
+        mission_key,
+        df[label_col],
+        label_mode=label_mode,
+    )
     valid_mask = labels.notna()
     df = df.loc[valid_mask].copy()
     labels = labels.loc[valid_mask].astype(int)
@@ -334,9 +368,32 @@ def load_mission_dataset(mission: str, data_dir: Path, logger: Optional[logging.
     features, canonical = _extract_canonical_features(filtered)
     features = _append_additional_numeric(features, filtered)
     features = features.dropna(axis=1, how="all")
-    metadata = _build_metadata(mission_key, feature_source, raw_labels, canonical)
-    logger.info("Mission %s: %d samples, %d features after leak removal", mission_key, len(features), features.shape[1])
-    return MissionDataset(mission=mission_key, features=features, labels=labels, metadata=metadata)
+    metadata = _build_metadata(
+        mission_key,
+        feature_source,
+        raw_labels,
+        canonical,
+        bucket_labels=bucket_labels.loc[valid_mask] if bucket_labels is not None else None,
+    )
+    if label_mode == "nasa":
+        class_names = ["non-planet", "candidate", "planet"]
+    else:
+        class_names = ["non-planet", "planet"]
+    logger.info(
+        "Mission %s: %d samples, %d features after leak removal (label_mode=%s)",
+        mission_key,
+        len(features),
+        features.shape[1],
+        label_mode,
+    )
+    return MissionDataset(
+        mission=mission_key,
+        features=features,
+        labels=labels,
+        metadata=metadata,
+        label_mode=label_mode,
+        class_names=list(class_names),
+    )
 
 
 def combine_datasets(datasets: Iterable[MissionDataset]) -> MissionDataset:
@@ -349,13 +406,27 @@ def combine_datasets(datasets: Iterable[MissionDataset]) -> MissionDataset:
     combined_metadata = pd.concat([dataset.metadata for dataset in datasets], axis=0, sort=False)
     combined_metadata["mission"] = combined_metadata["mission"].astype(str)
     tag = "+".join(sorted(set(missions)))
-    return MissionDataset(mission=tag, features=combined_features, labels=combined_labels, metadata=combined_metadata)
+    label_modes = {dataset.label_mode for dataset in datasets}
+    if len(label_modes) != 1:
+        raise ValueError("All datasets must share the same label_mode to combine.")
+    label_mode = label_modes.pop()
+    class_names = datasets[0].class_names if datasets else []
+    return MissionDataset(
+        mission=tag,
+        features=combined_features,
+        labels=combined_labels,
+        metadata=combined_metadata,
+        label_mode=label_mode,
+        class_names=list(class_names),
+    )
 
 
 def load_cross_mission_split(
     test_mission: str,
     data_dir: Path,
     logger: Optional[logging.Logger] = None,
+    *,
+    label_mode: str = "binary",
 ) -> Tuple[MissionDataset, MissionDataset]:
     logger = logger or logging.getLogger(__name__)
     missions = set(MISSION_FILES.keys())
@@ -363,8 +434,11 @@ def load_cross_mission_split(
     if test_key not in missions:
         raise ValueError(f"Unknown test mission '{test_mission}'.")
     train_keys = sorted(missions - {test_key})
-    train_datasets = [load_mission_dataset(mission, data_dir, logger) for mission in train_keys]
-    test_dataset = load_mission_dataset(test_key, data_dir, logger)
+    train_datasets = [
+        load_mission_dataset(mission, data_dir, logger, label_mode=label_mode)
+        for mission in train_keys
+    ]
+    test_dataset = load_mission_dataset(test_key, data_dir, logger, label_mode=label_mode)
     train_dataset = combine_datasets(train_datasets)
     return train_dataset, test_dataset
 
@@ -420,8 +494,10 @@ def load_mission_df(
     mission: str,
     data_dir: Path,
     logger: Optional[logging.Logger] = None,
+    *,
+    label_mode: str = "binary",
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Return mission features and metadata data frames."""
 
-    dataset = load_mission_dataset(mission, data_dir, logger)
+    dataset = load_mission_dataset(mission, data_dir, logger, label_mode=label_mode)
     return dataset.features.copy(), dataset.metadata.copy()

--- a/src/exo_tabular.py
+++ b/src/exo_tabular.py
@@ -8,7 +8,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import joblib
 import numpy as np
@@ -29,8 +29,10 @@ if __package__ in (None, ""):
     from modeling import (
         build_pipeline,
         evaluate_binary_classification,
+        evaluate_multiclass_classification,
         fit_pipeline_with_fallback,
         plot_confusion_matrix,
+        plot_multiclass_confusion_matrix,
         plot_pr_curve,
         plot_roc_curve,
         save_metrics,
@@ -49,8 +51,10 @@ else:
     from .modeling import (
         build_pipeline,
         evaluate_binary_classification,
+        evaluate_multiclass_classification,
         fit_pipeline_with_fallback,
         plot_confusion_matrix,
+        plot_multiclass_confusion_matrix,
         plot_pr_curve,
         plot_roc_curve,
         save_metrics,
@@ -88,6 +92,12 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
         action="store_true",
         help="When predicting, use the calibrated threshold for candidate bucket",
     )
+    parser.add_argument(
+        "--label-mode",
+        choices=["binary", "nasa"],
+        default="nasa",
+        help="Label encoding to use during training and prediction",
+    )
     return parser.parse_args(list(argv))
 
 
@@ -110,6 +120,42 @@ def log_feature_set(features: pd.DataFrame, logger: logging.Logger) -> None:
     columns = list(features.columns)
     logger.info("Final feature count: %d", len(columns))
     logger.info("Feature columns: %s", columns)
+
+
+def _resolve_problem_type(label_mode: str) -> str:
+    return "multiclass" if label_mode == "nasa" else "binary"
+
+
+def _get_pipeline_model(pipeline) -> object:
+    if hasattr(pipeline, "named_steps") and "model" in pipeline.named_steps:
+        return pipeline.named_steps["model"]
+    raise AttributeError("Pipeline does not expose a 'model' step with classes_.")
+
+
+def _predict_proba_with_classes(pipeline, features: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
+    proba = pipeline.predict_proba(features)
+    model = _get_pipeline_model(pipeline)
+    if not hasattr(model, "classes_"):
+        raise AttributeError("Model does not provide classes_ attribute for probability alignment.")
+    classes = np.asarray(model.classes_)
+    return proba, classes
+
+
+def _find_class_index(classes: Sequence[int], target: int) -> int:
+    for idx, value in enumerate(classes):
+        if int(value) == target:
+            return idx
+    raise ValueError(f"Target class {target} not found in model classes {classes!r}")
+
+
+def _sanitize_class_name(name: str) -> str:
+    return name.replace("-", "_")
+
+
+def _build_probability_frame(proba: np.ndarray, class_names: Sequence[str]) -> pd.DataFrame:
+    sanitized = [_sanitize_class_name(name) for name in class_names]
+    columns = [f"proba_{name}" for name in sanitized]
+    return pd.DataFrame(proba, columns=columns)
 
 
 def _normalize_threshold(value: float) -> float:
@@ -208,15 +254,23 @@ def _train_cross_mission_core(
     oversample: bool,
     random_state: int,
     recall_target: float,
+    label_mode: str,
     logger: logging.Logger,
 ) -> Path:
-    train_dataset, test_dataset = load_cross_mission_split(test_mission, data_dir, logger)
+    train_dataset, test_dataset = load_cross_mission_split(
+        test_mission,
+        data_dir,
+        logger,
+        label_mode=label_mode,
+    )
     log_label_distribution("train", train_dataset, logger)
     log_label_distribution("test", test_dataset, logger)
     X_train, y_train = train_dataset.features, train_dataset.labels
     X_test, y_test = test_dataset.features, test_dataset.labels
     log_feature_set(X_train, logger)
     numeric_cols, categorical_cols = infer_feature_types(X_train)
+    problem_type = _resolve_problem_type(label_mode)
+    class_names = train_dataset.class_names or ["non-planet", "planet"]
     pipeline = fit_pipeline_with_fallback(
         build_pipeline,
         numeric_cols,
@@ -227,15 +281,28 @@ def _train_cross_mission_core(
         ensemble=ensemble,
         logger=logger,
         random_state=random_state,
-        builder_kwargs={"oversample": oversample},
+        builder_kwargs={
+            "oversample": oversample,
+            "problem_type": problem_type,
+            "class_names": class_names,
+        },
     )
-    proba = pipeline.predict_proba(X_test)[:, 1]
-    metrics = evaluate_binary_classification(
-        y_test,
-        proba,
-        thresholds=(0.5, 0.95),
-        recall_target=recall_target,
-    )
+    proba, classes = _predict_proba_with_classes(pipeline, X_test)
+    metrics: Dict[str, object]
+    preds: np.ndarray
+    if problem_type == "binary":
+        positive_index = _find_class_index(classes, 1)
+        proba_planet = proba[:, positive_index]
+        metrics = evaluate_binary_classification(
+            y_test,
+            proba_planet,
+            thresholds=(0.5, 0.95),
+            recall_target=recall_target,
+        )
+        preds = (proba_planet >= 0.5).astype(int)
+    else:
+        metrics = evaluate_multiclass_classification(y_test, proba, class_names)
+        preds = np.argmax(proba, axis=1)
     metrics["configuration"] = {
         "mode": "train",
         "split": "cross-mission",
@@ -244,15 +311,32 @@ def _train_cross_mission_core(
         "device": device,
         "oversample": oversample,
         "recall_target": recall_target,
+        "label_mode": label_mode,
+        "problem_type": problem_type,
     }
+    metrics["class_names"] = list(class_names)
     if "metrics" in artifacts:
         save_metrics(metrics, artifacts["metrics"])
-    if "roc" in artifacts:
-        plot_roc_curve(y_test, proba, artifacts["roc"])
-    if "pr" in artifacts:
-        plot_pr_curve(y_test, proba, artifacts["pr"])
-    if "confusion" in artifacts:
-        plot_confusion_matrix(y_test, proba, threshold=0.5, output_path=artifacts["confusion"])
+    if problem_type == "binary":
+        if "roc" in artifacts:
+            plot_roc_curve(y_test, proba_planet, artifacts["roc"])
+        if "pr" in artifacts:
+            plot_pr_curve(y_test, proba_planet, artifacts["pr"])
+        if "confusion" in artifacts:
+            plot_confusion_matrix(
+                y_test,
+                proba_planet,
+                threshold=0.5,
+                output_path=artifacts["confusion"],
+            )
+    else:
+        if "confusion" in artifacts:
+            plot_multiclass_confusion_matrix(
+                y_test,
+                preds,
+                class_names,
+                artifacts["confusion"],
+            )
     model_path = artifacts.get("model")
     if model_path is not None:
         joblib.dump(pipeline, model_path)
@@ -275,11 +359,13 @@ def train_cross_mission(
     oversample: bool = False,
     random_state: int = DEFAULT_RANDOM_STATE,
     recall_target: float = 0.6,
+    label_mode: str = "nasa",
     logger: Optional[logging.Logger] = None,
 ) -> Path:
     logger = logger or logging.getLogger("exo_tabular")
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    artifacts = _prepare_cross_mission_artifacts(test_mission, artifacts_dir)
+    tag = f"{test_mission}_{label_mode}" if label_mode else test_mission
+    artifacts = _prepare_cross_mission_artifacts(test_mission, artifacts_dir, prefix=tag)
     return _train_cross_mission_core(
         test_mission,
         data_dir,
@@ -289,6 +375,7 @@ def train_cross_mission(
         oversample=oversample,
         random_state=random_state,
         recall_target=recall_target,
+        label_mode=label_mode,
         logger=logger,
     )
 
@@ -299,6 +386,7 @@ def _load_cross_mission_predictions(
     *,
     model_path: Path,
     schema_path: Path,
+    label_mode: str,
     logger: logging.Logger,
 ) -> pd.DataFrame:
     if not model_path.exists():
@@ -307,19 +395,39 @@ def _load_cross_mission_predictions(
         raise FileNotFoundError(f"Feature schema not found at {schema_path}")
     pipeline = joblib.load(model_path)
     schema = load_feature_schema(schema_path)
-    _, test_dataset = load_cross_mission_split(test_mission, data_dir, logger)
+    _, test_dataset = load_cross_mission_split(
+        test_mission,
+        data_dir,
+        logger,
+        label_mode=label_mode,
+    )
     log_label_distribution("prediction_target", test_dataset, logger)
     features = align_to_schema(test_dataset.features, schema)
     log_feature_set(features, logger)
-    proba = pipeline.predict_proba(features)[:, 1]
+    proba, classes = _predict_proba_with_classes(pipeline, features)
+    problem_type = _resolve_problem_type(label_mode)
+    class_names = test_dataset.class_names or ["non-planet", "planet"]
     base = pd.DataFrame(
         {
             "object_id": test_dataset.metadata["object_id"].values,
             "mission": test_dataset.metadata["mission"].values,
-            "proba_planet": proba,
         }
     )
+    if problem_type == "binary":
+        positive_index = _find_class_index(classes, 1)
+        proba_planet = proba[:, positive_index]
+        base["proba_planet"] = proba_planet
+        pred_indices = (proba_planet >= 0.5).astype(int)
+    else:
+        probability_frame = _build_probability_frame(proba, class_names)
+        base = pd.concat([base, probability_frame], axis=1)
+        if "proba_planet" not in base.columns:
+            base["proba_planet"] = probability_frame.get("proba_planet", 0.0)
+        pred_indices = np.argmax(proba, axis=1)
+    base["predicted_class"] = [class_names[int(idx)] for idx in pred_indices]
     metadata_columns = ["object_id", "mission", "label_text"]
+    if "nasa_bucket" in test_dataset.metadata.columns:
+        metadata_columns.append("nasa_bucket")
     for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
         if column in test_dataset.metadata:
             metadata_columns.append(column)
@@ -332,12 +440,18 @@ def _load_cross_mission_predictions(
             missing,
             test_mission,
         )
-    keep_order = ["object_id", "mission", "proba_planet"]
+    prob_columns = [col for col in base.columns if col.startswith("proba_")]
+    keep_order = ["object_id", "mission"]
+    keep_order.extend(prob_columns)
+    if "predicted_class" in base.columns:
+        keep_order.append("predicted_class")
     for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
         if column in merged.columns:
             keep_order.append(column)
     if "label_text" in merged.columns:
         keep_order.append("label_text")
+    if "nasa_bucket" in merged.columns:
+        keep_order.append("nasa_bucket")
     return merged.loc[:, keep_order]
 
 
@@ -346,17 +460,21 @@ def predict_cross_mission(
     data_dir: Path,
     artifacts_dir: Path,
     model_path: Optional[Path] = None,
+    schema_path: Optional[Path] = None,
     *,
+    label_mode: str = "nasa",
     logger: Optional[logging.Logger] = None,
 ) -> pd.DataFrame:
     logger = logger or logging.getLogger("exo_tabular")
-    effective_model_path = model_path or artifacts_dir / f"model_{test_mission}.pkl"
-    schema_path = artifacts_dir / f"{test_mission}_feature_columns.json"
+    tag = f"{test_mission}_{label_mode}"
+    effective_model_path = model_path or artifacts_dir / f"model_{tag}.pkl"
+    effective_schema_path = schema_path or artifacts_dir / f"{tag}_feature_columns.json"
     return _load_cross_mission_predictions(
         test_mission,
         data_dir,
         model_path=effective_model_path,
-        schema_path=schema_path,
+        schema_path=effective_schema_path,
+        label_mode=label_mode,
         logger=logger,
     )
 
@@ -369,14 +487,19 @@ def train_group_kfold(
 ) -> None:
     if not args.mission:
         raise ValueError("--mission must be provided for group-kfold split")
-    dataset = load_mission_dataset(args.mission, data_dir, logger)
+    dataset = load_mission_dataset(args.mission, data_dir, logger, label_mode=args.label_mode)
     log_label_distribution(args.mission, dataset, logger)
     X, y = dataset.features, dataset.labels
     groups = dataset.metadata["group_id"]
     log_feature_set(X, logger)
     numeric_cols, categorical_cols = infer_feature_types(X)
+    problem_type = _resolve_problem_type(args.label_mode)
+    class_names = dataset.class_names or ["non-planet", "planet"]
     gkf = GroupKFold(n_splits=GROUP_KFOLD_SPLITS)
-    proba = np.zeros(len(y), dtype=float)
+    if problem_type == "binary":
+        proba = np.zeros(len(y), dtype=float)
+    else:
+        proba = np.zeros((len(y), len(class_names)), dtype=float)
     for fold, (train_idx, val_idx) in enumerate(gkf.split(X, y, groups=groups), start=1):
         logger.info("Training fold %d/%d", fold, GROUP_KFOLD_SPLITS)
         fold_pipeline = fit_pipeline_with_fallback(
@@ -389,15 +512,27 @@ def train_group_kfold(
             ensemble=args.ensemble,
             logger=logger,
             random_state=args.random_state + fold,
-            builder_kwargs={"oversample": args.oversample},
+            builder_kwargs={
+                "oversample": args.oversample,
+                "problem_type": problem_type,
+                "class_names": class_names,
+            },
         )
-        proba[val_idx] = fold_pipeline.predict_proba(X.iloc[val_idx])[:, 1]
-    metrics = evaluate_binary_classification(
-        y,
-        proba,
-        thresholds=(0.5, 0.95),
-        recall_target=args.recall_target,
-    )
+        fold_proba, fold_classes = _predict_proba_with_classes(fold_pipeline, X.iloc[val_idx])
+        if problem_type == "binary":
+            positive_index = _find_class_index(fold_classes, 1)
+            proba[val_idx] = fold_proba[:, positive_index]
+        else:
+            proba[val_idx, :] = fold_proba
+    if problem_type == "binary":
+        metrics = evaluate_binary_classification(
+            y,
+            proba,
+            thresholds=(0.5, 0.95),
+            recall_target=args.recall_target,
+        )
+    else:
+        metrics = evaluate_multiclass_classification(y, proba, class_names)
     metrics["configuration"] = {
         "mode": "train",
         "split": args.split,
@@ -407,11 +542,18 @@ def train_group_kfold(
         "folds": GROUP_KFOLD_SPLITS,
         "oversample": args.oversample,
         "recall_target": args.recall_target,
+        "label_mode": args.label_mode,
+        "problem_type": problem_type,
     }
+    metrics["class_names"] = list(class_names)
     save_metrics(metrics, artifacts["metrics"])
-    plot_roc_curve(y, proba, artifacts["roc"])
-    plot_pr_curve(y, proba, artifacts["pr"])
-    plot_confusion_matrix(y, proba, threshold=0.5, output_path=artifacts["confusion"])
+    if problem_type == "binary":
+        plot_roc_curve(y, proba, artifacts["roc"])
+        plot_pr_curve(y, proba, artifacts["pr"])
+        plot_confusion_matrix(y, proba, threshold=0.5, output_path=artifacts["confusion"])
+    else:
+        preds = np.argmax(proba, axis=1)
+        plot_multiclass_confusion_matrix(y, preds, class_names, artifacts["confusion"])
     final_pipeline = fit_pipeline_with_fallback(
         build_pipeline,
         numeric_cols,
@@ -422,7 +564,11 @@ def train_group_kfold(
         ensemble=args.ensemble,
         logger=logger,
         random_state=args.random_state,
-        builder_kwargs={"oversample": args.oversample},
+        builder_kwargs={
+            "oversample": args.oversample,
+            "problem_type": problem_type,
+            "class_names": class_names,
+        },
     )
     joblib.dump(final_pipeline, artifacts["model"])
     save_feature_schema(X.columns, artifacts["schema"])
@@ -443,39 +589,43 @@ def predict_dataset(
             data_dir,
             model_path=model_path,
             schema_path=schema_path,
+            label_mode=args.label_mode,
             logger=logger,
         )
-        thresholds = {"planet": 0.95, "candidate": 0.5}
-        if args.use_calibrated_buckets:
-            calibrated = _load_calibrated_threshold(artifacts["metrics"])
-            if calibrated is not None:
-                if calibrated >= thresholds["planet"]:
-                    logger.warning(
-                        (
-                            "Calibrated candidate threshold %.4f for mission %s is >= planet "
-                            "threshold %.2f; keeping candidate threshold %.2f"
-                        ),
-                        calibrated,
-                        args.test_mission,
-                        thresholds["planet"],
-                        thresholds["candidate"],
-                    )
+        if args.label_mode == "binary":
+            thresholds = {"planet": 0.95, "candidate": 0.5}
+            if args.use_calibrated_buckets:
+                calibrated = _load_calibrated_threshold(artifacts["metrics"])
+                if calibrated is not None:
+                    if calibrated >= thresholds["planet"]:
+                        logger.warning(
+                            (
+                                "Calibrated candidate threshold %.4f for mission %s is >= planet "
+                                "threshold %.2f; keeping candidate threshold %.2f"
+                            ),
+                            calibrated,
+                            args.test_mission,
+                            thresholds["planet"],
+                            thresholds["candidate"],
+                        )
+                    else:
+                        thresholds["candidate"] = calibrated
+                        logger.info(
+                            "Using calibrated candidate threshold %.4f for mission %s",
+                            calibrated,
+                            args.test_mission,
+                        )
                 else:
-                    thresholds["candidate"] = calibrated
-                    logger.info(
-                        "Using calibrated candidate threshold %.4f for mission %s",
-                        calibrated,
-                        args.test_mission,
+                    logger.warning(
+                        "Calibrated threshold requested but not found at %s",
+                        artifacts["metrics"],
                     )
-            else:
-                logger.warning(
-                    "Calibrated threshold requested but not found at %s",
-                    artifacts["metrics"],
-                )
-        predictions["bucket"] = assign_bucket(
-            predictions["proba_planet"].to_numpy(),
-            thresholds=thresholds,
-        )
+            predictions["bucket"] = assign_bucket(
+                predictions["proba_planet"].to_numpy(),
+                thresholds=thresholds,
+            )
+        else:
+            predictions["bucket"] = predictions["predicted_class"]
     else:
         if not model_path.exists():
             raise FileNotFoundError(f"Trained model not found at {model_path}")
@@ -485,46 +635,81 @@ def predict_dataset(
         schema = load_feature_schema(schema_path)
         if not args.mission:
             raise ValueError("--mission must be provided for group-kfold split")
-        target_dataset = load_mission_dataset(args.mission, data_dir, logger)
+        target_dataset = load_mission_dataset(
+            args.mission,
+            data_dir,
+            logger,
+            label_mode=args.label_mode,
+        )
         log_label_distribution("prediction_target", target_dataset, logger)
         features = align_to_schema(target_dataset.features, schema)
         log_feature_set(features, logger)
-        proba = pipeline.predict_proba(features)[:, 1]
-        thresholds = {"planet": 0.95, "candidate": 0.5}
-        if args.use_calibrated_buckets:
-            calibrated = _load_calibrated_threshold(artifacts["metrics"])
-            if calibrated is not None:
-                if calibrated >= thresholds["planet"]:
-                    logger.warning(
-                        (
-                            "Calibrated candidate threshold %.4f for mission %s is >= planet "
-                            "threshold %.2f; keeping candidate threshold %.2f"
-                        ),
-                        calibrated,
-                        args.mission,
-                        thresholds["planet"],
-                        thresholds["candidate"],
-                    )
+        proba, classes = _predict_proba_with_classes(pipeline, features)
+        problem_type = _resolve_problem_type(args.label_mode)
+        class_names = target_dataset.class_names or ["non-planet", "planet"]
+        if problem_type == "binary":
+            positive_index = _find_class_index(classes, 1)
+            proba_planet = proba[:, positive_index]
+            thresholds = {"planet": 0.95, "candidate": 0.5}
+            if args.use_calibrated_buckets:
+                calibrated = _load_calibrated_threshold(artifacts["metrics"])
+                if calibrated is not None:
+                    if calibrated >= thresholds["planet"]:
+                        logger.warning(
+                            (
+                                "Calibrated candidate threshold %.4f for mission %s is >= planet "
+                                "threshold %.2f; keeping candidate threshold %.2f"
+                            ),
+                            calibrated,
+                            args.mission,
+                            thresholds["planet"],
+                            thresholds["candidate"],
+                        )
+                    else:
+                        thresholds["candidate"] = calibrated
+                        logger.info(
+                            "Using calibrated candidate threshold %.4f for mission %s",
+                            calibrated,
+                            args.mission,
+                        )
                 else:
-                    thresholds["candidate"] = calibrated
-                    logger.info(
-                        "Using calibrated candidate threshold %.4f for mission %s",
-                        calibrated,
-                        args.mission,
+                    logger.warning(
+                        "Calibrated threshold requested but not found at %s",
+                        artifacts["metrics"],
                     )
-            else:
-                logger.warning(
-                    "Calibrated threshold requested but not found at %s",
-                    artifacts["metrics"],
-                )
-        predictions = pd.DataFrame(
-            {
-                "object_id": target_dataset.metadata["object_id"].values,
-                "mission": target_dataset.metadata["mission"].values,
-                "proba_planet": proba,
-                "bucket": assign_bucket(proba, thresholds=thresholds),
-            }
-        )
+            buckets = assign_bucket(proba_planet, thresholds=thresholds)
+            pred_indices = (proba_planet >= 0.5).astype(int)
+            predictions = pd.DataFrame(
+                {
+                    "object_id": target_dataset.metadata["object_id"].values,
+                    "mission": target_dataset.metadata["mission"].values,
+                    "proba_planet": proba_planet,
+                    "bucket": buckets,
+                    "predicted_class": [class_names[int(idx)] for idx in pred_indices],
+                }
+            )
+        else:
+            probability_frame = _build_probability_frame(proba, class_names)
+            predictions = pd.concat(
+                [
+                    pd.DataFrame(
+                        {
+                            "object_id": target_dataset.metadata["object_id"].values,
+                            "mission": target_dataset.metadata["mission"].values,
+                        }
+                    ),
+                    probability_frame,
+                ],
+                axis=1,
+            )
+            if "proba_planet" not in predictions.columns:
+                predictions["proba_planet"] = probability_frame.get("proba_planet", 0.0)
+            pred_indices = np.argmax(proba, axis=1)
+            predictions["predicted_class"] = [class_names[int(idx)] for idx in pred_indices]
+            predictions["bucket"] = predictions["predicted_class"]
+        predictions["label_text"] = target_dataset.metadata["label_text"].values
+        if "nasa_bucket" in target_dataset.metadata.columns:
+            predictions["nasa_bucket"] = target_dataset.metadata["nasa_bucket"].values
         for column in dataio.PHYSICAL_OUTPUT_COLUMNS:
             if column in target_dataset.metadata:
                 predictions[column] = target_dataset.metadata[column].values
@@ -543,6 +728,7 @@ def main(argv: Iterable[str]) -> None:
         mode_tag = f"{args.split}_{args.mission}"
     else:
         mode_tag = args.split
+    mode_tag = f"{mode_tag}_{args.label_mode}"
     artifacts = build_artifact_paths(artifacts_dir, mode_tag)
     logger.info("Running mode=%s split=%s", args.mode, args.split)
     if args.mode == "train":
@@ -556,6 +742,7 @@ def main(argv: Iterable[str]) -> None:
                 oversample=args.oversample,
                 random_state=args.random_state,
                 recall_target=args.recall_target,
+                label_mode=args.label_mode,
                 logger=logger,
             )
         else:

--- a/src/export_predictions.py
+++ b/src/export_predictions.py
@@ -218,6 +218,7 @@ def run_cross_mission(args: argparse.Namespace) -> None:
             oversample=args.oversample,
             random_state=args.random_state,
             recall_target=args.recall_target,
+            label_mode="binary",
             logger=logger,
         )
         logger.info("Predicting mission %s", mission)
@@ -226,12 +227,13 @@ def run_cross_mission(args: argparse.Namespace) -> None:
             data_dir,
             artifacts_dir,
             model_path=model_path,
+            label_mode="binary",
             logger=logger,
         )
         _log_join_gaps(predictions, mission, logger)
         mission_thresholds = dict(base_thresholds)
         if args.use_calibrated_thresholds:
-            metrics_path = artifacts_dir / f"metrics_{mission}.json"
+            metrics_path = artifacts_dir / f"metrics_{mission}_binary.json"
             calibrated = _load_calibrated_threshold(metrics_path)
             if calibrated is not None:
                 if calibrated >= mission_thresholds["planet"]:

--- a/src/modeling.py
+++ b/src/modeling.py
@@ -22,6 +22,8 @@ from sklearn.metrics import (
     RocCurveDisplay,
     average_precision_score,
     confusion_matrix,
+    accuracy_score,
+    log_loss,
     precision_recall_fscore_support,
     roc_auc_score,
 )
@@ -68,17 +70,27 @@ def build_preprocessor(numeric_cols: Sequence[str], categorical_cols: Sequence[s
     return ColumnTransformer(transformers=transformers)
 
 
-def _instantiate_lgbm(device: str, random_state: int = 42) -> LGBMClassifier:
+def _instantiate_lgbm(
+    device: str,
+    random_state: int = 42,
+    *,
+    objective: str = "binary",
+    num_class: Optional[int] = None,
+) -> LGBMClassifier:
     params = {
         "n_estimators": 600,
         "learning_rate": 0.05,
         "num_leaves": 64,
         "subsample": 0.7,
         "colsample_bytree": 0.7,
-        "objective": "binary",
+        "objective": objective,
         "random_state": random_state,
         "n_jobs": -1,
     }
+    if objective == "multiclass":
+        if num_class is None:
+            raise ValueError("num_class must be provided for multiclass objective")
+        params["num_class"] = num_class
     if device == "gpu":
         params.update(
             {
@@ -100,6 +112,8 @@ def build_pipeline(
     ensemble: bool = False,
     random_state: int = 42,
     oversample: bool = False,
+    problem_type: str = "binary",
+    class_names: Optional[Sequence[str]] = None,
 ) -> Pipeline:
     preprocessor = build_preprocessor(numeric_cols, categorical_cols)
     aligner = ColumnAligner()
@@ -107,8 +121,16 @@ def build_pipeline(
         raise ImportError(
             "imbalanced-learn is required for oversampling. Install it with 'pip install imbalanced-learn'."
         )
+    if problem_type not in {"binary", "multiclass"}:
+        raise ValueError(f"Unsupported problem_type '{problem_type}'.")
+    num_class = len(class_names) if class_names is not None else None
+    lgbm = _instantiate_lgbm(
+        device=device,
+        random_state=random_state,
+        objective="multiclass" if problem_type == "multiclass" else "binary",
+        num_class=num_class,
+    )
     if ensemble:
-        lgbm = _instantiate_lgbm(device=device, random_state=random_state)
         rf = RandomForestClassifier(
             n_estimators=400,
             max_depth=None,
@@ -126,6 +148,7 @@ def build_pipeline(
             max_iter=1000,
             solver="lbfgs",
             class_weight="balanced",
+            multi_class="auto",
         )
         stacking = StackingClassifier(
             estimators=[
@@ -141,7 +164,7 @@ def build_pipeline(
         )
         model = stacking
     else:
-        model = _instantiate_lgbm(device=device, random_state=random_state)
+        model = lgbm
     steps = [
         ("align", aligner),
         ("preprocess", preprocessor),
@@ -166,6 +189,8 @@ def build_lightgbm_pipeline(
     categorical_cols: Sequence[str],
     *,
     random_state: int = 42,
+    problem_type: str = "binary",
+    class_names: Optional[Sequence[str]] = None,
 ) -> Pipeline:
     """Build a LightGBM-only pipeline with deterministic column alignment."""
 
@@ -184,6 +209,11 @@ def build_lightgbm_pipeline(
         "objective": "binary",
         "device_type": "cpu",
     }
+    if problem_type == "multiclass":
+        num_class = len(class_names) if class_names is not None else None
+        if not num_class:
+            raise ValueError("class_names must be provided for multiclass problems")
+        params.update({"objective": "multiclass", "num_class": num_class})
     model = LGBMClassifier(**params)
     pipeline = Pipeline(
         steps=[
@@ -328,6 +358,60 @@ def evaluate_binary_classification(
     return metrics
 
 
+def evaluate_multiclass_classification(
+    y_true: Sequence[int],
+    proba: np.ndarray,
+    class_names: Sequence[str],
+) -> Dict[str, object]:
+    y_true_arr = np.asarray(y_true)
+    proba_arr = np.asarray(proba)
+    if proba_arr.ndim != 2:
+        raise ValueError("Probability array for multiclass evaluation must be 2-dimensional.")
+    preds = np.argmax(proba_arr, axis=1)
+    num_classes = proba_arr.shape[1]
+    if num_classes != len(class_names):
+        raise ValueError("Number of classes in probabilities does not match class_names length.")
+    metrics: Dict[str, object] = {}
+    metrics["num_samples"] = int(len(y_true_arr))
+    metrics["accuracy"] = float(accuracy_score(y_true_arr, preds))
+    precision, recall, f1, support = precision_recall_fscore_support(
+        y_true_arr,
+        preds,
+        labels=np.arange(num_classes),
+        zero_division=0,
+    )
+    per_class: Dict[str, Dict[str, float]] = {}
+    for idx, name in enumerate(class_names):
+        per_class[name] = {
+            "precision": float(precision[idx]),
+            "recall": float(recall[idx]),
+            "f1": float(f1[idx]),
+            "support": int(support[idx]),
+        }
+    metrics["per_class"] = per_class
+    metrics["macro_f1"] = float(np.mean(f1))
+    metrics["true_distribution"] = {
+        class_names[idx]: int(np.sum(y_true_arr == idx)) for idx in range(num_classes)
+    }
+    metrics["predicted_distribution"] = {
+        class_names[idx]: int(np.sum(preds == idx)) for idx in range(num_classes)
+    }
+    try:
+        metrics["log_loss"] = float(log_loss(y_true_arr, proba_arr))
+    except ValueError:
+        metrics["log_loss"] = float("nan")
+    try:
+        metrics["roc_auc_ovr"] = float(
+            roc_auc_score(y_true_arr, proba_arr, multi_class="ovr")
+        )
+    except ValueError:
+        metrics["roc_auc_ovr"] = float("nan")
+    cm = confusion_matrix(y_true_arr, preds, labels=np.arange(num_classes))
+    metrics["confusion_matrix"] = cm.tolist()
+    metrics["class_names"] = list(class_names)
+    return metrics
+
+
 def save_metrics(metrics: Dict[str, object], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(metrics, indent=2))
@@ -361,6 +445,23 @@ def plot_confusion_matrix(y_true: Sequence[int], proba: Sequence[float], thresho
     disp = ConfusionMatrixDisplay(confusion_matrix=cm)
     disp.plot(ax=ax, cmap="Blues", colorbar=False)
     ax.set_title(f"Confusion Matrix (threshold={threshold:.2f})")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_multiclass_confusion_matrix(
+    y_true: Sequence[int],
+    preds: Sequence[int],
+    class_names: Sequence[str],
+    output_path: Path,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cm = confusion_matrix(y_true, preds, labels=np.arange(len(class_names)))
+    fig, ax = plt.subplots(figsize=(5, 5))
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm, display_labels=class_names)
+    disp.plot(ax=ax, cmap="Blues", colorbar=False)
+    ax.set_title("Confusion Matrix")
     fig.tight_layout()
     fig.savefig(output_path, dpi=150)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- add a NASA label mode that keeps planetary, candidate, and non-planet dispositions through data loading and model training
- extend modeling utilities and CLI workflows to train/evaluate multiclass LightGBM pipelines and emit per-class metrics/confusion matrices
- update prediction and export flows to surface per-class probabilities, predicted buckets, and label mode-aware artifact names, with documentation for the new flag

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68f16320d8b083268beb2f83bfa974b5